### PR TITLE
feat: add database service and REST table handler

### DIFF
--- a/src/lib/DatabaseService.ts
+++ b/src/lib/DatabaseService.ts
@@ -1,0 +1,60 @@
+import {Kysely, PostgresDialect, SqliteDialect} from 'kysely'
+import BetterSqlite3 from 'better-sqlite3'
+import {Pool} from 'pg'
+import {DatabaseSchema, SupportedDialect} from './entities'
+
+// -----------------------------------------------------------------------------
+// DatabaseService - singleton access to Kysely instance
+// -----------------------------------------------------------------------------
+
+export class DatabaseService {
+  private static instance: Kysely<DatabaseSchema> | null = null
+  private static _dialect: SupportedDialect
+
+  /** Return the current SQL dialect. Throws if database not initialized. */
+  public static get dialect(): SupportedDialect {
+    if (!this.instance) {
+      throw new Error('DatabaseService not initialized')
+    }
+    return this._dialect
+  }
+
+  /** Get or create the shared Kysely instance. */
+  public static async getInstance(): Promise<Kysely<DatabaseSchema>> {
+    if (this.instance) return this.instance
+
+    const url = process.env.DATABASE_URL
+    if (!url) {
+      throw new Error('DATABASE_URL not configured')
+    }
+
+    if (url.startsWith('sqlite://')) {
+      const filename = url.replace('sqlite://', '')
+      const sqlite = new BetterSqlite3(filename)
+      this.instance = new Kysely<DatabaseSchema>({
+        dialect: new SqliteDialect({database: sqlite}),
+      })
+      this._dialect = 'sqlite'
+    } else if (url.startsWith('postgres://') || url.startsWith('postgresql://')) {
+      const pool = new Pool({connectionString: url})
+      this.instance = new Kysely<DatabaseSchema>({
+        dialect: new PostgresDialect({pool}),
+      })
+      this._dialect = 'postgres'
+    } else {
+      throw new Error(`Unsupported DATABASE_URL: ${url}`)
+    }
+
+    return this.instance
+  }
+
+  /** Destroy the shared Kysely instance (useful for tests). */
+  public static async destroy(): Promise<void> {
+    if (this.instance) {
+      await this.instance.destroy()
+      this.instance = null
+      // dialect will be re-initialized on next getInstance call
+    }
+  }
+}
+

--- a/src/lib/restapi/BaseHandler.ts
+++ b/src/lib/restapi/BaseHandler.ts
@@ -2,6 +2,7 @@ import type {NextApiRequest, NextApiResponse} from 'next';
 import {ParsedUrlQuery} from 'querystring'
 import {Kysely} from "kysely";
 import {DatabaseSchema} from "../entities";
+import {DatabaseService} from "../DatabaseService";
 
 export enum ErrorCode {
     NOT_FOUND = 404,
@@ -42,9 +43,8 @@ export abstract class BaseHandler<T> {
     }
 
     protected get db(): Promise<Kysely<DatabaseSchema>> {
-        // @Todo: need to implement get or create method for Kysely instance
-        // @Todo: need to implement something like return DatabaseService.getOrCreate();
-        // process.env.DATABASE_URL, process.env.DATABASE_SCHEMA will be provided
+        // Delegate to DatabaseService singleton
+        return DatabaseService.getInstance();
     }
 
     protected error(code: ErrorCode, message?: string): void {

--- a/src/lib/restapi/BaseTableDataHandler.ts
+++ b/src/lib/restapi/BaseTableDataHandler.ts
@@ -1,73 +1,120 @@
-import {BaseHandler} from "./BaseHandler";
+import {Insertable, Kysely, Selectable, Updateable} from 'kysely'
+import {AbstractTable} from '../AbstractTable'
+import {DatabaseSchema} from '../entities'
+import {ensureValidId} from '../utilities'
+import {BaseHandler, ErrorCode, ResponseError} from './BaseHandler'
 
-// @Todo: the whole class needs to be refactored to use Kysely instead and the new AbstractTable
-export abstract class BaseTableDataHandler<E extends IJSONContent> extends BaseHandler<E[]> {
+// -----------------------------------------------------------------------------
+// BaseTableDataHandler - generic REST handler for an AbstractTable
+// -----------------------------------------------------------------------------
 
-    abstract getTable(): Promise<AJSONTable<E>>;
+/**
+ * Generic REST handler that wires HTTP verbs to repository operations
+ * implemented by {@link AbstractTable}. Subclasses only need to provide
+ * a repository instance via {@link getTable}.
+ */
+export abstract class BaseTableDataHandler<
+  TableName extends keyof DatabaseSchema
+> extends BaseHandler<Array<Selectable<DatabaseSchema[TableName]>>> {
 
-    async patch(body: any): Promise<void> {
-        const table = await this.getTable();
+  /**
+   * Subclasses must return a repository instance for the table they manage.
+   * The repository is typically created using the Kysely instance from
+   * {@link BaseHandler.db} and should have its schema ensured prior to use.
+   */
+  protected abstract getTable(): Promise<AbstractTable<TableName>>
 
-        if (Object.keys(body).length === 2 && body.id !== undefined && body.priority !== undefined) {
-            await table.updatePriority(body.id, body.priority);
-        } else {
-            await table.updateOne(body);
-        }
+  // ----- GET: fetch list or single row by id
+  protected async get(params: Record<string, string>): Promise<void> {
+    const table = await this.getTable()
 
-        await this.postProcess(await this.db);
-        const result = await table.selectById(body.id!);
-        if (result) {
-            this.ok([result]);
-        } else {
-            this.error(ErrorCode.NOT_FOUND);
-        }
+    if (params['id'] !== undefined) {
+      const id = Number(params['id'])
+      if (!Number.isInteger(id)) {
+        throw new ResponseError(ErrorCode.BAD_REQUEST, 'Invalid id')
+      }
+
+      const row = await table.getById(id)
+      if (row) {
+        this.ok(await this.postGet([row]))
+      } else {
+        this.error(ErrorCode.NOT_FOUND)
+      }
+      return
     }
 
-    async get(params: Record<string, string>): Promise<void> {
-        let result: E[];
-        const table = await this.getTable();
-        if (params['id'] !== undefined) {
-            const id = assertValidNumber(params['id']);
-            result = [await table.selectById(id)]
-        } else if (params['parentId'] !== undefined) {
-            const parentId = assertValidNumber(params['parentId']);
-            result = await table.selectAllByParentId(parentId);
-        } else {
-            result = await table.selectAll();
-        }
+    const list = await table.list()
+    this.ok(await this.postGet(list))
+  }
 
-        this.ok(await this.postGet(result));
+  // ----- POST: create new row
+  protected async post(body: Insertable<DatabaseSchema[TableName]>): Promise<void> {
+    const table = await this.getTable()
+    const created = await table.create(body)
+    await this.postProcess(await this.db)
+    this.ok([created])
+  }
+
+  // ----- PATCH: update existing row or priority
+  protected async patch(
+    body: Updateable<DatabaseSchema[TableName]> & { id: number }
+  ): Promise<void> {
+    const table = await this.getTable()
+    ensureValidId(body.id)
+
+    let updated
+    if (
+      typeof (body as any).priority === 'number' &&
+      Object.keys(body).length === 2
+    ) {
+      updated = await table.updatePriority(body.id, (body as any).priority)
+    } else {
+      const { id, ...rest } = body as any
+      updated = await table.update(id, rest)
     }
 
-    async post(body: any): Promise<void> {
-        const table = await this.getTable();
-        const id = await table.insertOne(body);
-        await this.postProcess(await this.db);
-        const result = await table.selectById(id);
-        if (result) {
-            this.ok([result]);
-        } else {
-            this.error(ErrorCode.NOT_FOUND, 'Rule not found after insert');
-        }
+    if (updated) {
+      await this.postProcess(await this.db)
+      this.ok([updated])
+    } else {
+      this.error(ErrorCode.NOT_FOUND)
     }
+  }
 
-    async delete(body: any): Promise<void> {
-        const table = await this.getTable();
-        const result = await table.selectById(assertValidId(body.id));
-        if (result) {
-            await table.deleteById(body.id);
-            await this.postProcess(await this.db);
-            this.ok([result]);
-        } else {
-            this.error(ErrorCode.NOT_FOUND);
-        }
-    }
+  // ----- DELETE: soft delete
+  protected async delete(body: { id: number }): Promise<void> {
+    const table = await this.getTable()
+    ensureValidId(body.id)
 
-    protected async postProcess(db: DatabaseService): Promise<void> {
-        // not implemented
+    const deleted = await table.delete(body.id)
+    if (deleted) {
+      await this.postProcess(await this.db)
+      this.ok([deleted])
+    } else {
+      this.error(ErrorCode.NOT_FOUND)
     }
+  }
 
-    protected async postGet(result: E[]): Promise<E[]> {
-        return result;
-    }
+  // ----- Hooks for subclasses -------------------------------------------------
+
+  /**
+   * Optional hook executed after mutating operations (POST, PATCH, DELETE).
+   * Subclasses can override to perform additional actions such as cache
+   * invalidation.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected async postProcess(db: Kysely<DatabaseSchema>): Promise<void> {
+    // Default: no-op
+  }
+
+  /**
+   * Optional hook executed before sending GET results to the client. Allows
+   * subclasses to transform or filter the result set.
+   */
+  protected async postGet(
+    result: Array<Selectable<DatabaseSchema[TableName]>>
+  ): Promise<Array<Selectable<DatabaseSchema[TableName]>>> {
+    return result
+  }
 }
+

--- a/src/tests/rest.test.ts
+++ b/src/tests/rest.test.ts
@@ -1,0 +1,82 @@
+import type {NextApiRequest, NextApiResponse} from 'next'
+import {BaseTableDataHandler} from '../lib/restapi/BaseTableDataHandler'
+import {UsersRepository} from './UsersRepository'
+import {DatabaseService} from '../lib/DatabaseService'
+
+// Simple helper to create mock Next.js request/response objects
+function createMock(method: string, body: any = {}, query: any = {}) {
+  const req = {method, body, query} as unknown as NextApiRequest
+  const res: any = {
+    statusCode: 0,
+    data: undefined as any,
+    status(code: number) {
+      this.statusCode = code
+      return this
+    },
+    json(payload: any) {
+      this.data = payload
+      return this
+    },
+    end() {
+      return this
+    },
+    setHeader() {
+      /* no-op for tests */
+    },
+    statusMessage: '',
+  }
+  return {req, res: res as NextApiResponse}
+}
+
+// Handler implementation for tests
+class UsersHandler extends BaseTableDataHandler<'users'> {
+  protected async getTable(): Promise<UsersRepository> {
+    const repo = new UsersRepository(await this.db, DatabaseService.dialect)
+    await repo.ensureSchema()
+    return repo
+  }
+}
+
+describe('BaseTableDataHandler REST flow', () => {
+  beforeEach(() => {
+    // Each test gets a fresh in-memory database
+    process.env.DATABASE_URL = 'sqlite://:memory:'
+  })
+
+  afterEach(async () => {
+    await DatabaseService.destroy()
+  })
+
+  test('create, fetch, update and delete', async () => {
+    // ---- Create
+    let {req, res} = createMock('POST', {
+      name: 'John',
+      surname: 'Doe',
+      telephone_number: '123',
+    })
+    await new UsersHandler(req, res).handle()
+    expect(res.statusCode).toBe(200)
+    const created = (res as any).data[0]
+    expect(created).toMatchObject({name: 'John'})
+
+    const id = created.id
+
+    // ---- Fetch
+    ;({req, res} = createMock('GET', undefined, {id: String(id)}))
+    await new UsersHandler(req, res).handle()
+    expect(res.statusCode).toBe(200)
+    expect((res as any).data[0].id).toBe(id)
+
+    // ---- Update
+    ;({req, res} = createMock('PATCH', {id, name: 'Jane'}))
+    await new UsersHandler(req, res).handle()
+    expect(res.statusCode).toBe(200)
+    expect((res as any).data[0].name).toBe('Jane')
+
+    // ---- Delete
+    ;({req, res} = createMock('DELETE', {id}))
+    await new UsersHandler(req, res).handle()
+    expect(res.statusCode).toBe(200)
+  })
+})
+

--- a/src/types/pg.d.ts
+++ b/src/types/pg.d.ts
@@ -1,0 +1,5 @@
+declare module 'pg' {
+  // Minimal declaration for Pool to satisfy TypeScript in tests
+  export const Pool: any
+}
+


### PR DESCRIPTION
## Summary
- implement singleton `DatabaseService` for database access
- connect `BaseHandler` to new service
- rewrite `BaseTableDataHandler` with Kysely repositories
- add REST handler tests for CRUD flow

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ce9dc5b1c832db090883309847956