### PR TITLE
Implement SQL API and add ColumnType enum

### DIFF
--- a/src/lib/entities.ts
+++ b/src/lib/entities.ts
@@ -1,15 +1,15 @@
-import {ColumnType, Generated} from "kysely";
+import {ColumnType as KyselyColumnType, Generated} from "kysely";
 
 export type SupportedDialect = 'postgres' | 'sqlite'
 
-export type TimestampDefault = ColumnType<Date, Date | string | undefined, Date | string | undefined>
+export type TimestampDefault = KyselyColumnType<Date, Date | string | undefined, Date | string | undefined>
 
-export type NullableTimestampDefault = ColumnType<
+export type NullableTimestampDefault = KyselyColumnType<
     Date | null,
     Date | string | null | undefined,
     Date | string | null | undefined
 >
-export type PriorityColumn = ColumnType<number, number | undefined, number | undefined>
+export type PriorityColumn = KyselyColumnType<number, number | undefined, number | undefined>
 
 export interface BaseTable {
     id: Generated<number>
@@ -29,11 +29,19 @@ export interface DatabaseSchema {
     users: UsersTable
 }
 
-// @Todo: implement enum ColumnType and use it in ColumnSpec
+export enum ColumnType {
+    STRING = 'string',
+    INTEGER = 'integer',
+    BOOLEAN = 'boolean',
+    TIMESTAMP = 'timestamp',
+    TIMESTAMPTZ = 'timestamptz',
+    JSON = 'json',
+    JSONB = 'jsonb',
+}
 
 export type ColumnSpec = {
     name: string
-    type: string // e.g. 'varchar(255)', 'boolean', 'integer', 'timestamp', 'timestamptz', 'jsonb'
+    type: ColumnType
     notNull?: boolean
     defaultSql?: string // raw SQL default, e.g. 'CURRENT_TIMESTAMP' or "'{}'::jsonb"
     unique?: boolean

--- a/src/lib/sqlapi/ISQLApi.ts
+++ b/src/lib/sqlapi/ISQLApi.ts
@@ -1,8 +1,138 @@
-// @Todo: implement SQLLiteApi and PostgresApi by extending this interface
+import {Kysely, PostgresDialect, SqliteDialect, sql} from 'kysely'
+import BetterSqlite3 from 'better-sqlite3'
+import {Pool} from 'pg'
+import {ColumnSpec, ColumnType, DatabaseSchema, SupportedDialect} from '../entities'
+
 export interface ISQLApi {
-    // @Todo: implement toStringType(type: ColumnType): string;
-
-    // @Todo: implement syncColumns(...): Promise<boolean>; (returns true if schema was changed)
-
-    // @Todo: implement createInstance - extract it from DatabaseService
+    toStringType(type: ColumnType): string
+    syncColumns(
+        db: Kysely<any>,
+        tableName: string,
+        columns: ColumnSpec[],
+        schemaName?: string
+    ): Promise<boolean>
 }
+
+export class SqliteApi implements ISQLApi {
+    toStringType(type: ColumnType): string {
+        switch (type) {
+            case ColumnType.STRING:
+                return 'text'
+            case ColumnType.INTEGER:
+                return 'integer'
+            case ColumnType.BOOLEAN:
+                return 'integer'
+            case ColumnType.TIMESTAMP:
+            case ColumnType.TIMESTAMPTZ:
+                return 'timestamp'
+            case ColumnType.JSON:
+            case ColumnType.JSONB:
+                return 'text'
+            default:
+                return 'text'
+        }
+    }
+
+    async syncColumns(db: Kysely<any>, tableName: string, columns: ColumnSpec[]): Promise<boolean> {
+        const pragma = await sql<{ name: string }>`PRAGMA table_info(${sql.raw(String(tableName))});`.execute(db)
+        const existing = new Set(pragma.rows.map(r => r.name))
+        const toAdd = columns.filter(c => !existing.has(c.name))
+        if (toAdd.length === 0) return false
+        for (const column of toAdd) {
+            await db.schema
+                .alterTable(tableName)
+                .addColumn(
+                    column.name,
+                    this.toStringType(column.type) as any,
+                    col => {
+                        if (column.notNull && column.defaultSql) col = col.notNull().defaultTo(sql.raw(column.defaultSql))
+                        else if (column.notNull) col = col.notNull()
+                        if (column.unique) col = col.unique()
+                        if (column.defaultSql) col = col.defaultTo(sql.raw(column.defaultSql))
+                        return col
+                    }
+                )
+                .execute()
+        }
+        return true
+    }
+}
+
+export class PostgresApi implements ISQLApi {
+    toStringType(type: ColumnType): string {
+        switch (type) {
+            case ColumnType.STRING:
+                return 'varchar(255)'
+            case ColumnType.INTEGER:
+                return 'integer'
+            case ColumnType.BOOLEAN:
+                return 'boolean'
+            case ColumnType.TIMESTAMP:
+                return 'timestamp'
+            case ColumnType.TIMESTAMPTZ:
+                return 'timestamptz'
+            case ColumnType.JSON:
+                return 'json'
+            case ColumnType.JSONB:
+                return 'jsonb'
+            default:
+                return 'text'
+        }
+    }
+
+    async syncColumns(
+        db: Kysely<any>,
+        tableName: string,
+        columns: ColumnSpec[],
+        schemaName = 'public'
+    ): Promise<boolean> {
+        const rows = await sql<{ column_name: string }>`
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = ${schemaName}
+              AND table_name = ${tableName}
+        `.execute(db)
+        const existing = new Set(rows.rows.map(r => r.column_name))
+        const toAdd = columns.filter(c => !existing.has(c.name))
+        if (toAdd.length === 0) return false
+        for (const column of toAdd) {
+            await db.schema
+                .alterTable(tableName)
+                .addColumn(
+                    column.name,
+                    this.toStringType(column.type) as any,
+                    col => {
+                        if (column.notNull && column.defaultSql) col = col.notNull().defaultTo(sql.raw(column.defaultSql))
+                        else if (column.notNull) col = col.notNull()
+                        if (column.unique) col = col.unique()
+                        if (column.defaultSql) col = col.defaultTo(sql.raw(column.defaultSql))
+                        return col
+                    }
+                )
+                .execute()
+        }
+        return true
+    }
+}
+
+export async function createInstance(
+    url: string
+): Promise<{ db: Kysely<DatabaseSchema>; dialect: SupportedDialect; api: ISQLApi }> {
+    if (url.startsWith('sqlite://')) {
+        const filename = url.replace('sqlite://', '')
+        const sqlite = new BetterSqlite3(filename)
+        const db = new Kysely<DatabaseSchema>({
+            dialect: new SqliteDialect({ database: sqlite })
+        })
+        return { db, dialect: 'sqlite', api: new SqliteApi() }
+    }
+    if (url.startsWith('postgres://') || url.startsWith('postgresql://')) {
+        const pool = new Pool({ connectionString: url })
+        const db = new Kysely<DatabaseSchema>({
+            dialect: new PostgresDialect({ pool })
+        })
+        return { db, dialect: 'postgres', api: new PostgresApi() }
+    }
+    throw new Error(`Unsupported DATABASE_URL: ${url}`)
+}
+

--- a/src/tests/UsersRepository.ts
+++ b/src/tests/UsersRepository.ts
@@ -2,20 +2,20 @@
 // Example repository: Users (define extra columns here only)
 // -----------------------------------------------------------------------------
 import {Kysely} from "kysely";
-import {ColumnSpec, DatabaseSchema, SupportedDialect} from "../lib/entities";
+import {ColumnSpec, ColumnType, DatabaseSchema, SupportedDialect} from "../lib/entities";
 import {AbstractTable} from "../lib/AbstractTable";
+import {ISQLApi} from "../lib/sqlapi/ISQLApi";
 
 export class UsersRepository extends AbstractTable<'users'> {
-    constructor(database: Kysely<DatabaseSchema>, dialect: SupportedDialect) {
-        super(database, 'users', dialect)
+    constructor(database: Kysely<DatabaseSchema>, dialect: SupportedDialect, sqlApi: ISQLApi) {
+        super(database, 'users', dialect, sqlApi)
     }
 
     protected extraColumns(): ColumnSpec[] {
-        const textType = this.dialect === 'postgres' ? 'varchar(255)' : 'text'
         return [
-            {name: 'name', type: textType, notNull: true},
-            {name: 'surname', type: textType, notNull: true},
-            {name: 'telephone_number', type: textType, notNull: true},
+            {name: 'name', type: ColumnType.STRING, notNull: true},
+            {name: 'surname', type: ColumnType.STRING, notNull: true},
+            {name: 'telephone_number', type: ColumnType.STRING, notNull: true},
         ]
     }
 }

--- a/src/tests/rest.test.ts
+++ b/src/tests/rest.test.ts
@@ -31,7 +31,7 @@ function createMock(method: string, body: any = {}, query: any = {}) {
 // Handler implementation for tests
 class UsersHandler extends BaseTableDataHandler<'users'> {
   protected async getTable(): Promise<UsersRepository> {
-    const repo = new UsersRepository(await this.db, DatabaseService.dialect)
+    const repo = new UsersRepository(await this.db, DatabaseService.dialect, DatabaseService.sqlApi)
     await repo.ensureSchema()
     return repo
   }

--- a/src/tests/users.test.ts
+++ b/src/tests/users.test.ts
@@ -2,6 +2,7 @@ import {Kysely, SqliteDialect} from 'kysely'
 import BetterSqlite3 from 'better-sqlite3'
 import {DatabaseSchema} from "../lib/entities";
 import {UsersRepository} from "./UsersRepository";
+import {SqliteApi} from "../lib/sqlapi/ISQLApi";
 
 describe('UsersRepository CRUD', () => {
     let db: Kysely<DatabaseSchema>
@@ -10,7 +11,7 @@ describe('UsersRepository CRUD', () => {
     beforeEach(async () => {
         const sqlite = new BetterSqlite3(':memory:')
         db = new Kysely<DatabaseSchema>({dialect: new SqliteDialect({database: sqlite})})
-        repo = new UsersRepository(db, 'sqlite')
+        repo = new UsersRepository(db, 'sqlite', new SqliteApi())
         await repo.ensureSchema()
     })
 


### PR DESCRIPTION
## Summary
- introduce `ColumnType` enum and update column specs
- add SQL API implementations for SQLite and Postgres
- refactor DatabaseService to create instances via SQL API

## Testing
- `npm test`
- `npm run build`
- `npm run lint` *(fails: 'params' is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c5f48314832daafa59d56714b889