### PR TITLE
refactor: implement ColumnType todos

### DIFF
--- a/src/lib/entities.ts
+++ b/src/lib/entities.ts
@@ -30,23 +30,15 @@ export interface DatabaseSchema {
 }
 
 export enum ColumnType {
-
-    // @Todo: string is varchar max 255 in Postgres and TEXT in SQLite
+    // Maps to varchar(255) in Postgres and TEXT in SQLite
     STRING = 'string',
     INTEGER = 'integer',
     BOOLEAN = 'boolean',
     TIMESTAMP = 'timestamp',
-
-    // @Todo: drop TIMESTAMPTZ support, only TIMESTAMP is needed
-    TIMESTAMPTZ = 'timestamptz',
-
-    // @Todo: use 'jsonb' for Postgres and TEXT for SQLite
+    // Maps to jsonb in Postgres and TEXT in SQLite
     JSON = 'json',
-
-    // @Todo: remove JSONB - API will allow JSON
-    JSONB = 'jsonb',
-
-    // @Todo: add TEXT and use 'text' for Postgres and TEXT for SQLite
+    // Maps to text in both Postgres and SQLite
+    TEXT = 'text',
 }
 
 export type ColumnSpec = {

--- a/src/lib/restapi/BaseHandler.ts
+++ b/src/lib/restapi/BaseHandler.ts
@@ -113,22 +113,27 @@ export abstract class BaseHandler<T> {
         }
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     protected async get(params: Record<string, string>) {
         this.error(ErrorCode.METHOD_NOT_ALLOWED);
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     protected async post(body: any) {
         this.error(ErrorCode.METHOD_NOT_ALLOWED);
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     protected async put(body: any) {
         this.error(ErrorCode.METHOD_NOT_ALLOWED);
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     protected async patch(body: any) {
         this.error(ErrorCode.METHOD_NOT_ALLOWED);
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     protected async delete(body: any) {
         this.error(ErrorCode.METHOD_NOT_ALLOWED);
     }

--- a/src/lib/sqlapi/ISQLApi.ts
+++ b/src/lib/sqlapi/ISQLApi.ts
@@ -23,10 +23,9 @@ export class SqliteApi implements ISQLApi {
             case ColumnType.BOOLEAN:
                 return 'integer'
             case ColumnType.TIMESTAMP:
-            case ColumnType.TIMESTAMPTZ:
                 return 'timestamp'
             case ColumnType.JSON:
-            case ColumnType.JSONB:
+            case ColumnType.TEXT:
                 return 'text'
             default:
                 return 'text'
@@ -69,12 +68,10 @@ export class PostgresApi implements ISQLApi {
                 return 'boolean'
             case ColumnType.TIMESTAMP:
                 return 'timestamp'
-            case ColumnType.TIMESTAMPTZ:
-                return 'timestamptz'
             case ColumnType.JSON:
-                return 'json'
-            case ColumnType.JSONB:
                 return 'jsonb'
+            case ColumnType.TEXT:
+                return 'text'
             default:
                 return 'text'
         }


### PR DESCRIPTION
## Summary
- remove unused TIMESTAMPTZ and JSONB column types and add TEXT
- map STRING, JSON and TEXT types to dialect-specific SQL types
- silence unused parameter warnings in BaseHandler

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1ce4b4e3c832d8c6c9b0775e0e3b2