### PR TITLE
feat: add request data cache repository

### DIFF
--- a/src/lib/AbstractCacheTable.ts
+++ b/src/lib/AbstractCacheTable.ts
@@ -1,0 +1,231 @@
+import {Insertable, Kysely, Updateable, sql} from 'kysely'
+import {AbstractTable} from './AbstractTable'
+import {ColumnSpec, ColumnType, DatabaseSchema, SupportedDialect} from './entities'
+import {ISQLApi} from './sqlapi/ISQLApi'
+
+export enum TTL {
+  ONE_HOUR = 3600,
+  ONE_DAY = 86400,
+  ONE_WEEK = 604800,
+  ONE_MONTH = 2592000,
+  ONE_YEAR = 31536000,
+  NOT_EXPIRED = -1,
+  EXPIRED = -2,
+  UNLIMITED = 0,
+}
+
+export interface CacheEntryKey {
+  type: string
+}
+
+export interface CacheEntry<T> extends CacheEntryKey {
+  id: number
+  data: T
+  createdAt: Date
+  expired: boolean | number | null
+}
+
+export abstract class AbstractCacheTable<
+  TableName extends keyof DatabaseSchema
+> extends AbstractTable<TableName> {
+  constructor(
+    database: Kysely<DatabaseSchema>,
+    tableName: TableName,
+    dialect: SupportedDialect,
+    sqlApi: ISQLApi,
+  ) {
+    super(database, tableName, dialect, sqlApi)
+  }
+
+  protected extraColumns(): ColumnSpec[] {
+    return [
+      {name: 'type', type: ColumnType.TEXT, notNull: true},
+      {name: 'data', type: ColumnType.JSON, notNull: true},
+      {name: 'expired', type: ColumnType.BOOLEAN},
+    ]
+  }
+
+  async expireEntries(select: Partial<CacheEntryKey>, ttl: TTL): Promise<number> {
+    if (ttl <= 0) throw new Error(`TTL ${ttl} is not supported for expiration`)
+    this.ensureSelectNotEmpty(select)
+    const qb = this.db
+      .updateTable(this.tableName as string)
+      .set({expired: this.expiredValue(true)} as unknown as Updateable<DatabaseSchema[TableName]>)
+
+    const qbWithFilters = this.applyKeyFilters(qb, select)
+      .where(({eb, ref}: any) => eb(ref('created_at'), '>=', this.nowMinusSecondsExpr(ttl)))
+      .where(this.notExpiredPredicate())
+
+    const res = await qbWithFilters.executeTakeFirst()
+    const n = (res as any)?.numUpdatedRows ?? 0n
+    return Number(n)
+  }
+
+  async cleanExpiredEntries(select: Partial<CacheEntryKey>): Promise<number> {
+    this.ensureSelectNotEmpty(select)
+    const qb = this.applyKeyFilters(
+      this.db.deleteFrom(this.tableName as string),
+      select,
+    ).where(this.expiredPredicate())
+
+    const res = await qb.executeTakeFirst()
+    const n = (res as any)?.numDeletedRows ?? 0n
+    return Number(n)
+  }
+
+  async get<T>(select: Partial<CacheEntryKey>, ttl?: TTL): Promise<T | null> {
+    this.ensureSelectNotEmpty(select)
+
+    let qb = this.applyKeyFilters(
+      this.db.selectFrom(this.tableName as string).select(['data']),
+      select,
+    )
+
+    qb = this.applyTtlFilters(qb, ttl ?? TTL.NOT_EXPIRED)
+      .orderBy('created_at', 'desc')
+      .orderBy('id', 'desc')
+      .limit(1)
+
+    const row = await qb.executeTakeFirst()
+    if (!row) return null
+    const val = (row as any).data
+    return this.decodeJson<T>(val)
+  }
+
+  async getAll<T>(select: Partial<CacheEntryKey>, ttl?: TTL): Promise<CacheEntry<T>[]> {
+    this.ensureSelectNotEmpty(select)
+
+    let qb = this.applyKeyFilters(
+      this.db
+        .selectFrom(this.tableName as string)
+        .select(['id', 'data', 'created_at', 'type', 'expired']),
+      select,
+    )
+
+    qb = this.applyTtlFilters(qb, ttl ?? TTL.NOT_EXPIRED)
+      .orderBy('created_at', 'desc')
+      .orderBy('id', 'desc')
+
+    const rows = await qb.execute()
+    return rows.map((r: any) => ({
+      id: r.id,
+      type: r.type,
+      data: this.decodeJson<T>(r.data),
+      expired: r.expired,
+      createdAt: this.asDate(r.created_at),
+    }))
+  }
+
+  async save<T>(key: CacheEntryKey, data: T): Promise<boolean> {
+    if (data === undefined || data === null) return false
+
+    const values = {
+      type: key.type,
+      data: this.encodeJson(data),
+      created_at: sql`CURRENT_TIMESTAMP`,
+      expired: this.expiredValue(false),
+    }
+
+    try {
+      await this.db
+        .insertInto(this.tableName as string)
+        .values(values as Insertable<DatabaseSchema[TableName]>)
+        .returning(['id'])
+        .executeTakeFirst()
+      return true
+    } catch {
+      try {
+        await this.db
+          .insertInto(this.tableName as string)
+          .values(values as Insertable<DatabaseSchema[TableName]>)
+          .executeTakeFirst()
+        return true
+      } catch (e2) {
+        console.error('Error in save:', e2)
+        return false
+      }
+    }
+  }
+
+  protected ensureSelectNotEmpty(select: Partial<CacheEntryKey>) {
+    if (!select || Object.values(select).every(v => v === undefined)) {
+      throw new Error('No values provided for where clause')
+    }
+  }
+
+  protected applyKeyFilters<T extends { where: any }>(qb: T, select: Partial<CacheEntryKey>): T {
+    let out: any = qb
+    if (select.type !== undefined) out = out.where('type', '=', select.type)
+    return out
+  }
+
+  protected applyTtlFilters<T extends { where: any }>(qb: T, ttl: TTL): T {
+    let out: any = qb
+    switch (ttl) {
+      case TTL.NOT_EXPIRED:
+        out = out.where(this.notExpiredPredicate())
+        break
+      case TTL.EXPIRED:
+        out = out.where(this.expiredPredicate())
+        break
+      case TTL.UNLIMITED:
+        break
+      default:
+        out = out
+          .where(({eb, ref}: any) => eb(ref('created_at'), '>=', this.nowMinusSecondsExpr(ttl)))
+          .where(this.notExpiredPredicate())
+        break
+    }
+    return out
+  }
+
+  protected notExpiredPredicate() {
+    return this.dialect === 'postgres'
+      ? sql<boolean>`expired IS NOT TRUE`
+      : sql<boolean>`COALESCE(expired, 0) = 0`
+  }
+
+  protected expiredPredicate() {
+    return this.dialect === 'postgres'
+      ? sql<boolean>`expired IS TRUE`
+      : sql<boolean>`expired = 1`
+  }
+
+  protected expiredValue(val: boolean) {
+    return this.dialect === 'postgres' ? val : val ? 1 : 0
+  }
+
+  protected nowMinusSecondsExpr(ttlSeconds: number) {
+    if (this.dialect === 'postgres') {
+      return sql<Date>`now() - make_interval(secs => ${ttlSeconds})`
+    }
+    return sql<string>`datetime('now', '-' || ${ttlSeconds} || ' seconds')`
+  }
+
+  protected asDate(dt: string | Date): Date {
+    return dt instanceof Date ? dt : new Date(dt)
+  }
+
+  protected encodeJson(value: unknown): unknown {
+    return this.dialect === 'postgres' ? value : JSON.stringify(value)
+  }
+
+  protected encodeJsonOrNull(value: unknown | null | undefined): unknown | null {
+    if (value == null) return null
+    return this.encodeJson(value)
+  }
+
+  protected decodeJson<T>(value: unknown): T {
+    if (value == null) return value as T
+    if (this.dialect === 'postgres') return value as T
+    if (typeof value === 'string') {
+      try {
+        return JSON.parse(value) as T
+      } catch {
+        /* pass */
+      }
+    }
+    return value as T
+  }
+}
+

--- a/src/lib/entities.ts
+++ b/src/lib/entities.ts
@@ -25,8 +25,18 @@ export interface UsersTable extends BaseTable {
     telephone_number: string
 }
 
+export interface RequestDataCacheTable extends BaseTable {
+    request_url: string
+    reference: string | null
+    type: string
+    data: unknown
+    metadata: unknown | null
+    expired: boolean | number | null
+}
+
 export interface DatabaseSchema {
     users: UsersTable
+    request_data_cache: RequestDataCacheTable
 }
 
 export enum ColumnType {

--- a/src/tests/RequestDataRepository.ts
+++ b/src/tests/RequestDataRepository.ts
@@ -1,0 +1,126 @@
+import {Kysely, sql} from 'kysely'
+import {AbstractCacheTable, TTL} from '../lib/AbstractCacheTable'
+import {ColumnSpec, ColumnType, DatabaseSchema, SupportedDialect} from '../lib/entities'
+import {ISQLApi} from '../lib/sqlapi/ISQLApi'
+
+export interface CacheEntryKey {
+  requestUrl: string
+  type: string
+  reference?: string
+}
+
+export interface CacheEntry<T> extends CacheEntryKey {
+  id: number
+  data: T
+  metadata: any
+  createdAt: Date
+  expired: boolean | number | null
+}
+
+export default class RequestDataRepository extends AbstractCacheTable<'request_data_cache'> {
+  constructor(db: Kysely<DatabaseSchema>, dialect: SupportedDialect, sqlApi: ISQLApi) {
+    super(db, 'request_data_cache', dialect, sqlApi)
+  }
+
+  private priorityCounter = 0
+
+  protected extraColumns(): ColumnSpec[] {
+    return [
+      {name: 'request_url', type: ColumnType.STRING, notNull: true},
+      {name: 'reference', type: ColumnType.STRING},
+      {name: 'metadata', type: ColumnType.JSON},
+      ...super.extraColumns(),
+    ]
+  }
+
+  protected applyKeyFilters<T extends { where: any }>(qb: T, select: Partial<CacheEntryKey>): T {
+    let out: any = qb
+    if (select.requestUrl !== undefined) out = out.where('request_url', '=', select.requestUrl)
+    if (select.type !== undefined) out = out.where('type', '=', select.type)
+    if (select.reference !== undefined) out = out.where('reference', '=', select.reference)
+    return out
+  }
+
+  async get<T>(select: Partial<CacheEntryKey>, ttl?: TTL): Promise<T | null> {
+    this.ensureSelectNotEmpty(select)
+    let qb = this.applyKeyFilters(
+      this.db.selectFrom(this.tableName as string).select(['data']),
+      select,
+    )
+    qb = this.applyTtlFilters(qb, ttl ?? TTL.NOT_EXPIRED)
+      .orderBy('created_at', 'desc')
+      .orderBy('id', 'desc')
+      .limit(1)
+    const row = await qb.executeTakeFirst()
+    if (!row) return null
+    return this.decodeJson<T>((row as any).data)
+  }
+
+  async getAll<T>(select: Partial<CacheEntryKey>, ttl?: TTL): Promise<CacheEntry<T>[]> {
+    this.ensureSelectNotEmpty(select)
+    let qb = this.applyKeyFilters(
+      this.db
+        .selectFrom(this.tableName as string)
+        .select(['id', 'data', 'metadata', 'created_at', 'request_url', 'reference', 'type', 'expired']),
+      select,
+    )
+    qb = this.applyTtlFilters(qb, ttl ?? TTL.NOT_EXPIRED)
+      .orderBy('created_at', 'desc')
+      .orderBy('id', 'desc')
+    const rows = await qb.execute()
+    return rows.map((r: any) => ({
+      id: r.id,
+      requestUrl: r.request_url,
+      reference: r.reference ?? undefined,
+      type: r.type,
+      data: this.decodeJson<T>(r.data),
+      metadata: this.decodeJson<any>(r.metadata),
+      createdAt: this.asDate(r.created_at),
+      expired: r.expired,
+    }))
+  }
+
+  async save<T>(key: CacheEntryKey, data: T, metadata: object = {}): Promise<boolean> {
+    if (data === undefined || data === null) return false
+    const values = {
+      request_url: key.requestUrl,
+      reference: key.reference ?? null,
+      type: key.type,
+      data: this.encodeJson(data),
+      metadata: this.encodeJsonOrNull(metadata),
+      created_at: sql`CURRENT_TIMESTAMP`,
+      expired: this.expiredValue(false),
+      priority: this.priorityCounter++,
+    }
+    try {
+      await this.db
+        .insertInto(this.tableName as string)
+        .values(values as any)
+        .returning(['id'])
+        .executeTakeFirst()
+      return true
+    } catch {
+      try {
+        await this.db
+          .insertInto(this.tableName as string)
+          .values(values as any)
+          .executeTakeFirst()
+        return true
+      } catch (e2) {
+        console.error('Error in save:', e2)
+        return false
+      }
+    }
+  }
+
+  async expireEntries(select: Partial<CacheEntryKey>, ttl: TTL): Promise<number> {
+    // Cast is safe: base implementation will ignore extra fields via applyKeyFilters override
+    return super.expireEntries(select as any, ttl)
+  }
+
+  async cleanExpiredEntries(select: Partial<CacheEntryKey>): Promise<number> {
+    return super.cleanExpiredEntries(select as any)
+  }
+}
+
+export {TTL}

--- a/src/tests/requestDataRepository.test.ts
+++ b/src/tests/requestDataRepository.test.ts
@@ -1,0 +1,239 @@
+import {Kysely, SqliteDialect, sql} from 'kysely'
+import BetterSqlite3 from 'better-sqlite3'
+import RequestDataRepository, {CacheEntry, CacheEntryKey, TTL} from './RequestDataRepository'
+import {DatabaseSchema} from '../lib/entities'
+import {SQLiteApi} from '../lib/sqlapi/SQLiteApi'
+
+describe('DatabaseRequestDataCache', () => {
+  let db: Kysely<DatabaseSchema>
+  let cache: RequestDataRepository
+
+  const sampleKey: CacheEntryKey = {
+    requestUrl: 'https://api.example.com/data',
+    type: 'sampleType',
+    reference: 'ref123',
+  }
+  const sampleData = {foo: 'bar'}
+  const sampleMeta = {m: 1}
+
+  beforeEach(async () => {
+    const sqlite = new BetterSqlite3(':memory:')
+    db = new Kysely<DatabaseSchema>({dialect: new SqliteDialect({database: sqlite})})
+    cache = new RequestDataRepository(db, 'sqlite', new SQLiteApi())
+    await cache.ensureSchema()
+  })
+
+  afterEach(async () => {
+    await db.destroy()
+  })
+
+  it('save() should insert and return true', async () => {
+    const ok = await cache.save(sampleKey, sampleData, sampleMeta)
+    expect(ok).toBe(true)
+    const rows = await db
+      .selectFrom('request_data_cache')
+      .select(['request_url', 'type', 'reference', 'data', 'metadata'])
+      .execute()
+    expect(rows).toHaveLength(1)
+    const row = rows[0] as any
+    expect(row.request_url).toBe(sampleKey.requestUrl)
+    expect(row.type).toBe(sampleKey.type)
+    expect(row.reference).toBe(sampleKey.reference)
+    expect(JSON.parse(row.data)).toEqual(sampleData)
+    expect(JSON.parse(row.metadata)).toEqual(sampleMeta)
+  })
+
+  it('get() should return null when no entry exists', async () => {
+    const result = await cache.get(sampleKey)
+    expect(result).toBeNull()
+  })
+
+  it('get() and getAll() should retrieve saved entry', async () => {
+    await cache.save(sampleKey, sampleData, sampleMeta)
+    const got = await cache.get<typeof sampleData>(sampleKey)
+    expect(got).toEqual(sampleData)
+    const all = await cache.getAll<typeof sampleData>(sampleKey)
+    expect(all.length).toBe(1)
+    const entry: CacheEntry<typeof sampleData> = all[0]
+    expect(entry.requestUrl).toBe(sampleKey.requestUrl)
+    expect(entry.type).toBe(sampleKey.type)
+    expect(entry.reference).toBe(sampleKey.reference)
+    expect(entry.data).toEqual(sampleData)
+    expect(entry.metadata).toEqual(sampleMeta)
+    expect(entry.createdAt).toBeInstanceOf(Date)
+  })
+
+  it('getAll() with different TTL', async () => {
+    await cache.save({requestUrl: 'url1', type: 'TRANSACT', reference: 'expired'}, {a: 1}, {})
+    await cache.save({requestUrl: 'url2', type: 'TRANSACT', reference: 'fine'}, {a: 1}, {})
+    await cache.save({requestUrl: 'url3', type: 'TRANSACT', reference: 'outdated'}, {a: 1}, {})
+
+    await db
+      .updateTable('request_data_cache')
+      .set({expired: 1})
+      .where('reference', '=', 'expired')
+      .execute()
+
+    await db
+      .updateTable('request_data_cache')
+      .set({created_at: sql`datetime('now', '-' || ${TTL.ONE_HOUR * 2} || ' seconds')`})
+      .where('reference', '=', 'outdated')
+      .execute()
+
+    {
+      const oneHour = await cache.getAll({type: 'TRANSACT'}, TTL.ONE_HOUR)
+      expect(oneHour.length).toBe(1)
+
+      const all = await cache.getAll({type: 'TRANSACT'}, TTL.UNLIMITED)
+      expect(all.length).toBe(3)
+
+      const expired = await cache.getAll({type: 'TRANSACT'}, TTL.EXPIRED)
+      expect(expired.length).toBe(1)
+
+      const notExpired = await cache.getAll({type: 'TRANSACT'}, TTL.NOT_EXPIRED)
+      expect(notExpired.length).toBe(2)
+    }
+
+    await cache.expireEntries({type: 'TRANSACT'}, TTL.ONE_YEAR)
+
+    {
+      const oneHour = await cache.getAll({type: 'TRANSACT'}, TTL.ONE_HOUR)
+      expect(oneHour.length).toBe(0)
+
+      const all = await cache.getAll({type: 'TRANSACT'}, TTL.UNLIMITED)
+      expect(all.length).toBe(3)
+
+      const expired = await cache.getAll({type: 'TRANSACT'}, TTL.EXPIRED)
+      expect(expired.length).toBe(3)
+
+      const notExpired = await cache.getAll({type: 'TRANSACT'}, TTL.NOT_EXPIRED)
+      expect(notExpired.length).toBe(0)
+    }
+  })
+
+  it('get() with TTL should skip old entries', async () => {
+    await cache.save(sampleKey, {x: 1}, {})
+    await db
+      .updateTable('request_data_cache')
+      .set({created_at: sql`datetime('now', '-' || ${TTL.ONE_HOUR * 2} || ' seconds')`})
+      .execute()
+
+    const noTtl = await cache.get(sampleKey)
+    expect(noTtl).toEqual({x: 1})
+
+    const withTtl = await cache.get(sampleKey, TTL.ONE_HOUR)
+    expect(withTtl).toBeNull()
+  })
+
+  it('expireEntries() should mark matching rows expired', async () => {
+    await cache.save(sampleKey, {a: 1}, {})
+    await cache.save({...sampleKey, reference: 'other'}, {b: 2}, {})
+    const before = await db.selectFrom('request_data_cache').select(['expired']).execute()
+    expect(before.every(r => r.expired === 0)).toBe(true)
+
+    const affected = await cache.expireEntries({requestUrl: sampleKey.requestUrl, type: sampleKey.type}, TTL.ONE_DAY)
+    expect(affected).toBe(2)
+
+    const res = await db.selectFrom('request_data_cache').select(['reference', 'expired']).execute()
+    const map = new Map(res.map((r: any) => [r.reference, r.expired]))
+    expect(map.get(sampleKey.reference)).toBe(1)
+    expect(map.get('other')).toBe(1)
+  })
+
+  it('cleanExpiredEntries() should delete only expired rows', async () => {
+    await cache.save(sampleKey, sampleData, sampleMeta)
+    await cache.save({...sampleKey, reference: 'expired-ref'}, sampleData, sampleMeta)
+    await db.updateTable('request_data_cache').set({expired: 1}).where('reference', '=', 'expired-ref').execute()
+
+    const before = await db.selectFrom('request_data_cache').select(['reference']).execute()
+    expect(before.length).toBe(2)
+
+    const del = await cache.cleanExpiredEntries({requestUrl: sampleKey.requestUrl, type: sampleKey.type})
+    expect(del).toBe(1)
+
+    const after = await db.selectFrom('request_data_cache').select(['reference']).execute()
+    expect(after.length).toBe(1)
+    expect(after[0].reference).toBe(sampleKey.reference)
+  })
+
+  it('main test', async () => {
+    await cache.save({requestUrl: 'url1', type: 'TRANSACT', reference: 'ref1'}, {a: 1}, {})
+    await cache.save({requestUrl: 'url2', type: 'TRANSACT', reference: 'ref2'}, {b: 2}, {})
+    await cache.save({requestUrl: 'url3', type: 'TRANSACT', reference: 'ref3'}, {c: 3}, {})
+
+    await db
+      .updateTable('request_data_cache')
+      .set({created_at: sql`datetime('now', '-' || ${TTL.ONE_HOUR * 2} || ' seconds')`})
+      .execute()
+
+    {
+      const record1 = await cache.get({requestUrl: 'url1'}, TTL.ONE_HOUR * 2 + 1)
+      expect(record1).toEqual({a: 1})
+      const record2 = await cache.get({requestUrl: 'url2'}, TTL.ONE_HOUR * 2 + 1)
+      expect(record2).toEqual({b: 2})
+    }
+
+    {
+      const record1 = await cache.get({requestUrl: 'url1'}, TTL.ONE_HOUR)
+      expect(record1).toBeNull()
+    }
+
+    {
+      let record1 = await cache.get({requestUrl: 'url1', type: 'type1', reference: 'ref1'}, TTL.ONE_MONTH)
+      expect(record1).toBeNull()
+      record1 = await cache.get({requestUrl: 'url1', type: 'TRANSACT', reference: 'ref1'}, TTL.ONE_MONTH)
+      expect(record1).toEqual({a: 1})
+      record1 = await cache.get({type: 'TRANSACT'}, TTL.ONE_MONTH)
+      expect(record1).toEqual({c: 3})
+    }
+
+    {
+      const all = await cache.getAll({type: 'TRANSACT'}, TTL.ONE_MONTH)
+      expect(all.length).toBe(3)
+      expect(all[0].data).toStrictEqual({c: 3})
+      expect(all[1].data).toStrictEqual({b: 2})
+      expect(all[2].data).toStrictEqual({a: 1})
+    }
+  })
+
+  it('getAll returns the most recent first', async () => {
+    await cache.save({requestUrl: 'url1', type: 'TRANSACT', reference: 'ref1'}, {a: 1}, {})
+    await cache.save({requestUrl: 'url2', type: 'TRANSACT', reference: 'ref2'}, {b: 2}, {})
+    await cache.save({requestUrl: 'url3', type: 'TRANSACT', reference: 'ref3'}, {c: 3}, {})
+    await cache.save({requestUrl: 'url4', type: 'TRANSACT', reference: 'ref4'}, {d: 4}, {})
+
+    await db
+      .updateTable('request_data_cache')
+      .set({created_at: sql`datetime('now', '-' || ${TTL.ONE_HOUR} || ' seconds')`})
+      .where('reference', '=', 'ref1')
+      .execute()
+
+    await db
+      .updateTable('request_data_cache')
+      .set({created_at: sql`datetime('now', '-' || ${TTL.ONE_DAY} || ' seconds')`})
+      .where('reference', '=', 'ref2')
+      .execute()
+
+    await db
+      .updateTable('request_data_cache')
+      .set({created_at: sql`datetime('now', '-' || ${TTL.ONE_YEAR} || ' seconds')`})
+      .where('reference', '=', 'ref3')
+      .execute()
+
+    await db
+      .updateTable('request_data_cache')
+      .set({created_at: sql`datetime('now', '-' || ${TTL.ONE_WEEK} || ' seconds')`})
+      .where('reference', '=', 'ref4')
+      .execute()
+
+    const all = await cache.getAll({type: 'TRANSACT'}, TTL.UNLIMITED)
+    expect(all.length).toBe(4)
+    expect(all[0].data).toStrictEqual({a: 1})
+    expect(all[1].data).toStrictEqual({b: 2})
+    expect(all[2].data).toStrictEqual({d: 4})
+    expect(all[3].data).toStrictEqual({c: 3})
+
+    const one = await cache.get({type: 'TRANSACT'}, TTL.UNLIMITED)
+    expect(one).toStrictEqual({a: 1})
+  })
+})


### PR DESCRIPTION
## Summary
- expand cache table abstractions for custom key support
- introduce `RequestDataRepository` built on `AbstractCacheTable`
- add tests for TTL-based cache behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1daf39744832d80ee8a83e6f41ff9