### PR TITLE
feat: add SQL API factory and dialect support

### DIFF
--- a/src/lib/AbstractCacheTable.ts
+++ b/src/lib/AbstractCacheTable.ts
@@ -1,7 +1,6 @@
 import {Insertable, Kysely, Updateable, sql} from 'kysely'
 import {AbstractTable} from './AbstractTable'
-import {ColumnSpec, ColumnType, DatabaseSchema, SupportedDialect} from './entities'
-import {ISQLApi} from './sqlapi/ISQLApi'
+import {ColumnSpec, ColumnType, DatabaseSchema} from './entities'
 
 export enum TTL {
   ONE_HOUR = 3600,
@@ -31,10 +30,8 @@ export abstract class AbstractCacheTable<
   constructor(
     database: Kysely<DatabaseSchema>,
     tableName: TableName,
-    dialect: SupportedDialect,
-    sqlApi: ISQLApi,
   ) {
-    super(database, tableName, dialect, sqlApi)
+    super(database, tableName)
   }
 
   protected extraColumns(): ColumnSpec[] {

--- a/src/lib/sqlapi/PostgresSQLApi.ts
+++ b/src/lib/sqlapi/PostgresSQLApi.ts
@@ -1,8 +1,9 @@
-import {ColumnSpec, ColumnType} from "../entities";
-import {Kysely, sql} from "kysely";
+import {ColumnSpec, ColumnType, DatabaseSchema, SupportedDialect} from "../entities";
+import {Kysely, PostgresDialect, sql} from "kysely";
 import {ISQLApi} from "./ISQLApi";
 
 export class PostgresSQLApi implements ISQLApi {
+    dialect: SupportedDialect = 'postgres'
     toStringType(type: ColumnType): string {
         switch (type) {
             case ColumnType.STRING:
@@ -55,4 +56,13 @@ export class PostgresSQLApi implements ISQLApi {
         }
         return true
     }
+}
+
+export async function createPostgresInstance(url: string): Promise<Kysely<DatabaseSchema>> {
+    // Load pg only when creating a Postgres instance
+    const { Pool } = await import('pg')
+    const pool = new Pool({ connectionString: url })
+    return new Kysely<DatabaseSchema>({
+        dialect: new PostgresDialect({ pool })
+    })
 }

--- a/src/lib/sqlapi/SQLiteApi.ts
+++ b/src/lib/sqlapi/SQLiteApi.ts
@@ -1,8 +1,9 @@
-import {ColumnSpec, ColumnType} from "../entities";
-import {Kysely, sql} from "kysely";
+import {ColumnSpec, ColumnType, DatabaseSchema, SupportedDialect} from "../entities";
+import {Kysely, SqliteDialect, sql} from "kysely";
 import {ISQLApi} from "./ISQLApi";
 
 export class SQLiteApi implements ISQLApi {
+    dialect: SupportedDialect = 'sqlite'
     toStringType(type: ColumnType): string {
         switch (type) {
             case ColumnType.STRING:
@@ -44,4 +45,13 @@ export class SQLiteApi implements ISQLApi {
         }
         return true
     }
+}
+
+export async function createSqliteInstance(filename: string): Promise<Kysely<DatabaseSchema>> {
+    // Load better-sqlite3 only when creating a SQLite instance
+    const { default: BetterSqlite3 } = await import('better-sqlite3')
+    const sqlite = new BetterSqlite3(filename)
+    return new Kysely<DatabaseSchema>({
+        dialect: new SqliteDialect({ database: sqlite })
+    })
 }

--- a/src/tests/RequestDataRepository.ts
+++ b/src/tests/RequestDataRepository.ts
@@ -1,7 +1,6 @@
 import {Kysely, sql} from 'kysely'
 import {AbstractCacheTable, TTL} from '../lib/AbstractCacheTable'
-import {ColumnSpec, ColumnType, DatabaseSchema, SupportedDialect} from '../lib/entities'
-import {ISQLApi} from '../lib/sqlapi/ISQLApi'
+import {ColumnSpec, ColumnType, DatabaseSchema} from '../lib/entities'
 
 export interface CacheEntryKey {
   requestUrl: string
@@ -18,8 +17,8 @@ export interface CacheEntry<T> extends CacheEntryKey {
 }
 
 export default class RequestDataRepository extends AbstractCacheTable<'request_data_cache'> {
-  constructor(db: Kysely<DatabaseSchema>, dialect: SupportedDialect, sqlApi: ISQLApi) {
-    super(db, 'request_data_cache', dialect, sqlApi)
+  constructor(db: Kysely<DatabaseSchema>) {
+    super(db, 'request_data_cache')
   }
 
   private priorityCounter = 0

--- a/src/tests/UsersRepository.ts
+++ b/src/tests/UsersRepository.ts
@@ -1,13 +1,11 @@
 import {Kysely} from "kysely";
-import {ColumnSpec, ColumnType, DatabaseSchema, SupportedDialect} from "../lib/entities";
+import {ColumnSpec, ColumnType, DatabaseSchema} from "../lib/entities";
 import {AbstractTable} from "../lib/AbstractTable";
-import {ISQLApi} from "../lib/sqlapi/ISQLApi";
 
 export class UsersRepository extends AbstractTable<'users'> {
 
-    // @Todo, no reason to pass dialect, it is acquired from sqlApi
-    constructor(database: Kysely<DatabaseSchema>, dialect: SupportedDialect, sqlApi: ISQLApi) {
-        super(database, 'users', dialect, sqlApi)
+    constructor(database: Kysely<DatabaseSchema>) {
+        super(database, 'users')
     }
 
     protected extraColumns(): ColumnSpec[] {

--- a/src/tests/requestDataRepository.test.ts
+++ b/src/tests/requestDataRepository.test.ts
@@ -2,7 +2,6 @@ import {Kysely, SqliteDialect, sql} from 'kysely'
 import BetterSqlite3 from 'better-sqlite3'
 import RequestDataRepository, {CacheEntry, CacheEntryKey, TTL} from './RequestDataRepository'
 import {DatabaseSchema} from '../lib/entities'
-import {SQLiteApi} from '../lib/sqlapi/SQLiteApi'
 
 describe('DatabaseRequestDataCache', () => {
   let db: Kysely<DatabaseSchema>
@@ -19,7 +18,7 @@ describe('DatabaseRequestDataCache', () => {
   beforeEach(async () => {
     const sqlite = new BetterSqlite3(':memory:')
     db = new Kysely<DatabaseSchema>({dialect: new SqliteDialect({database: sqlite})})
-    cache = new RequestDataRepository(db, 'sqlite', new SQLiteApi())
+    cache = new RequestDataRepository(db)
     await cache.ensureSchema()
   })
 

--- a/src/tests/rest.test.ts
+++ b/src/tests/rest.test.ts
@@ -31,7 +31,7 @@ function createMock(method: string, body: any = {}, query: any = {}) {
 // Handler implementation for tests
 class UsersHandler extends BaseTableDataHandler<'users'> {
   protected async getTable(): Promise<UsersRepository> {
-    const repo = new UsersRepository(await this.db, DatabaseService.dialect, DatabaseService.sqlApi)
+    const repo = new UsersRepository(await this.db)
     await repo.ensureSchema()
     return repo
   }

--- a/src/tests/users.test.ts
+++ b/src/tests/users.test.ts
@@ -3,8 +3,6 @@ import BetterSqlite3 from 'better-sqlite3'
 import {DatabaseSchema} from "../lib/entities";
 import {UsersRepository} from "./UsersRepository";
 
-import {SQLiteApi} from "../lib/sqlapi/SQLiteApi";
-
 describe('UsersRepository CRUD', () => {
     let db: Kysely<DatabaseSchema>
     let repo: UsersRepository
@@ -12,8 +10,7 @@ describe('UsersRepository CRUD', () => {
     beforeEach(async () => {
         const sqlite = new BetterSqlite3(':memory:')
         db = new Kysely<DatabaseSchema>({dialect: new SqliteDialect({database: sqlite})})
-        // @Todo: use SQLApi factory instead of passing SQLiteApi directly
-        repo = new UsersRepository(db, 'sqlite', new SQLiteApi())
+        repo = new UsersRepository(db)
         await repo.ensureSchema()
     })
 


### PR DESCRIPTION
## Summary
- auto-detect SQL dialect from Kysely adapter and initialize SQL API
- move dialect-specific database creation into SQLite/Postgres APIs
- update DatabaseService and tests to use streamlined table constructors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1e1a8ac44832db30aff725db41286