### PR TITLE
feat: add path aliases for layers

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,8 @@ module.exports = {
         '**/__tests__/**/*.+(ts|tsx|js)',
         '**/*.(test|spec).+(ts|tsx|js)'
     ],
+    moduleNameMapper: {
+        '^@datalayer(.*)$': '<rootDir>/src/datalayer$1',
+        '^@servicelayer(.*)$': '<rootDir>/src/servicelayer$1'
+    }
 }

--- a/src/servicelayer/BaseTableDataHandler.ts
+++ b/src/servicelayer/BaseTableDataHandler.ts
@@ -1,8 +1,8 @@
 import {Insertable, Kysely, Selectable, Updateable} from 'kysely'
 import {BaseHandler, ErrorCode, ResponseError} from './BaseHandler'
-import {DatabaseSchema} from "../datalayer/entities";
-import {AbstractTable} from "../datalayer/AbstractTable";
-import {ensureValidId} from "../datalayer/utilities";
+import {DatabaseSchema} from "@datalayer/entities";
+import {AbstractTable} from "@datalayer/AbstractTable";
+import {ensureValidId} from "@datalayer/utilities";
 
 /**
  * Generic REST handler that wires HTTP verbs to repository operations

--- a/src/servicelayer/rest.test.ts
+++ b/src/servicelayer/rest.test.ts
@@ -1,9 +1,9 @@
 import type {NextApiRequest, NextApiResponse} from 'next'
 import {Kysely, SqliteDialect} from "kysely"
-import { DatabaseSchema } from "../datalayer/entities"
+import { DatabaseSchema } from "@datalayer/entities"
 import BetterSqlite3 from "better-sqlite3";
-import {BaseTableDataHandler} from "./BaseTableDataHandler";
-import {UsersRepository} from "../datalayer/_tests/UsersRepository";
+import {BaseTableDataHandler} from "@servicelayer/BaseTableDataHandler";
+import {UsersRepository} from "@datalayer/_tests/UsersRepository";
 
 // Simple helper to create mock Next.js request/response objects
 function createMock(method: string, body: any = {}, query: any = {}) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,14 @@
     "outDir": "dist",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "baseUrl": "src",
+    "paths": {
+      "@datalayer": ["datalayer"],
+      "@datalayer/*": ["datalayer/*"],
+      "@servicelayer": ["servicelayer"],
+      "@servicelayer/*": ["servicelayer/*"]
+    }
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- add TypeScript path aliases for datalayer and servicelayer
- update Jest config to resolve new aliases
- refactor imports to use new aliases

## Testing
- `npm test`
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1f1307c14832db57f5859222c9801