### PR TITLE
feat: add abstract json table

### DIFF
--- a/src/datalayer/AbstractJSONTable.ts
+++ b/src/datalayer/AbstractJSONTable.ts
@@ -1,0 +1,122 @@
+import {Insertable, Kysely, Selectable, Updateable} from 'kysely'
+import {AbstractTable} from './AbstractTable'
+import {ColumnSpec, ColumnType, DatabaseSchema} from './entities'
+import {IJSONContent} from './IJSONContent'
+
+/**
+ * Simple JSON storage table backed by a {@link AbstractTable}. Stores arbitrary
+ * JSON in a `content` column while exposing `id`, `type` and `priority` fields
+ * directly on the returned objects.
+ */
+export abstract class AbstractJSONTable<
+  TableName extends keyof DatabaseSchema,
+  Content extends IJSONContent,
+> extends AbstractTable<TableName> {
+  private readonly supportedTypes: string[]
+
+  constructor(
+    database: Kysely<DatabaseSchema>,
+    tableName: TableName,
+    supportedTypes: string[],
+  ) {
+    super(database, tableName)
+    this.supportedTypes = supportedTypes
+  }
+
+  protected extraColumns(): ColumnSpec[] {
+    return [
+      {name: 'type', type: ColumnType.STRING, notNull: true},
+      {name: 'content', type: ColumnType.JSON, notNull: true},
+    ]
+  }
+
+  protected encodeJson(value: unknown): unknown {
+    return this.dialect === 'postgres' ? value : JSON.stringify(value)
+  }
+
+  protected decodeJson(value: unknown): Record<string, unknown> {
+    if (value == null) return {} as Record<string, unknown>
+    if (this.dialect === 'postgres') return value as Record<string, unknown>
+    if (typeof value === 'string') {
+      try {
+        return JSON.parse(value) as Record<string, unknown>
+      } catch {
+        /* ignore */
+      }
+    }
+    return value as Record<string, unknown>
+  }
+
+  private toJsonContent(content: Partial<Content>): Record<string, unknown> {
+    const rest = {...(content as any)}
+    delete (rest as any).id
+    delete (rest as any).priority
+    delete (rest as any).type
+    return rest
+  }
+
+  private fromRow(row: Selectable<DatabaseSchema[TableName]>): Content {
+    const json = this.decodeJson((row as any).content)
+    return {
+      ...json,
+      id: (row as any).id,
+      priority: (row as any).priority,
+      type: (row as any).type,
+    } as Content
+  }
+
+  async createWithContent(content: Content): Promise<Content> {
+    const {type, priority} = content
+    if (!type) {
+      throw new Error('type must be provided')
+    }
+    if (this.supportedTypes.length && !this.supportedTypes.includes(type)) {
+      throw new Error(`Unsupported type: ${type}`)
+    }
+    const row = await super.create({
+      type,
+      priority: priority as any,
+      content: this.encodeJson(this.toJsonContent(content)),
+    } as Insertable<DatabaseSchema[TableName]>)
+    return this.fromRow(row)
+  }
+
+  async getByIdWithContent(
+    id: number,
+    options: {includeDeleted?: boolean} = {},
+  ): Promise<Content | undefined> {
+    const row = await super.getById(id, options)
+    return row ? this.fromRow(row) : undefined
+  }
+
+  async listWithContent(
+    options: {
+      includeDeleted?: boolean
+      limit?: number
+      offset?: number
+      orderBy?: {column: keyof DatabaseSchema[TableName]; direction?: 'asc' | 'desc'}
+    } = {},
+  ): Promise<Content[]> {
+    const rows = await super.list(options)
+    return rows.map(r => this.fromRow(r))
+  }
+
+  async updateWithContent(id: number, patch: Partial<Content>): Promise<Content | undefined> {
+    const {type, priority, ...jsonPatch} = patch as any
+    const updateData: any = {}
+    if (type !== undefined) {
+      if (this.supportedTypes.length && !this.supportedTypes.includes(type)) {
+        throw new Error(`Unsupported type: ${type}`)
+      }
+      updateData.type = type
+    }
+    if (priority !== undefined) updateData.priority = priority
+    if (Object.keys(jsonPatch).length) {
+      const current = await super.getById(id, {includeDeleted: true})
+      const existing = current ? this.decodeJson((current as any).content) : {}
+      updateData.content = this.encodeJson({...existing, ...jsonPatch})
+    }
+    const row = await super.update(id, updateData as Updateable<DatabaseSchema[TableName]>)
+    return row ? this.fromRow(row) : undefined
+  }
+}

--- a/src/datalayer/IJSONContent.ts
+++ b/src/datalayer/IJSONContent.ts
@@ -1,0 +1,5 @@
+export interface IJSONContent {
+  id?: number;
+  priority?: number;
+  type: string;
+}

--- a/src/datalayer/_tests/AbstractJSONTable.test.ts
+++ b/src/datalayer/_tests/AbstractJSONTable.test.ts
@@ -1,0 +1,102 @@
+import {Kysely, SqliteDialect} from 'kysely'
+import BetterSqlite3 from 'better-sqlite3'
+import {DatabaseSchema} from '../entities'
+import {DashboardConfigurationTable, DashboardConfiguration} from './DashboardConfigurationTable'
+
+describe('AbstractJSONTable', () => {
+  let db: Kysely<DatabaseSchema>
+  let table: DashboardConfigurationTable
+
+  beforeEach(async () => {
+    const sqlite = new BetterSqlite3(':memory:')
+    db = new Kysely<DatabaseSchema>({dialect: new SqliteDialect({database: sqlite})})
+    table = new DashboardConfigurationTable(db)
+    await table.ensureSchema()
+  })
+
+  afterEach(async () => {
+    await db.destroy()
+  })
+
+  test('create and read JSON content', async () => {
+    const config: DashboardConfiguration = {
+      type: 'DASHBOARD',
+      title: 'Main dashboard',
+      description: 'example',
+      panelsIds: [1, 2],
+      variables: {foo: 'bar'},
+    }
+    const created = await table.createWithContent(config)
+    expect(created.id).toBeDefined()
+    expect(created).toMatchObject({...config, priority: 0})
+
+    const fetched = await table.getByIdWithContent(created.id!)
+    expect(fetched).toEqual(created)
+  })
+
+  test('listWithContent returns all rows', async () => {
+    const configs: DashboardConfiguration[] = [
+      {type: 'DASHBOARD', title: 'One', description: 'd1', panelsIds: [], variables: {}, priority: 0},
+      {type: 'DASHBOARD', title: 'Two', description: 'd2', panelsIds: [], variables: {}, priority: 1},
+    ]
+    for (const c of configs) {
+      await table.createWithContent(c)
+    }
+    const list = await table.listWithContent({orderBy: {column: 'id'}})
+    expect(list).toHaveLength(2)
+    expect(list.map(c => c.title)).toEqual(['One', 'Two'])
+  })
+
+  test('updateWithContent merges JSON and updates fields', async () => {
+    const config: DashboardConfiguration = {
+      type: 'DASHBOARD',
+      title: 'Main',
+      description: 'old',
+      panelsIds: [],
+      variables: {},
+    }
+    const created = await table.createWithContent(config)
+    const updated = await table.updateWithContent(created.id!, {
+      description: 'new',
+      priority: 5,
+    })
+    expect(updated).toMatchObject({
+      ...config,
+      description: 'new',
+      priority: 5,
+    })
+  })
+
+  test('throws on missing type', async () => {
+    await expect(
+      // @ts-expect-error intentionally missing type
+      table.createWithContent({title: 't', description: 'd', panelsIds: [], variables: {}}),
+    ).rejects.toThrow('type must be provided')
+  })
+
+  test('throws on unsupported type', async () => {
+    // create
+    await expect(
+      table.createWithContent({
+        // @ts-expect-error testing runtime check
+        type: 'PANEL',
+        title: 'x',
+        description: 'd',
+        panelsIds: [],
+        variables: {},
+      }),
+    ).rejects.toThrow('Unsupported type')
+
+    const created = await table.createWithContent({
+      type: 'DASHBOARD',
+      title: 't',
+      description: 'd',
+      panelsIds: [],
+      variables: {},
+    })
+
+    await expect(
+      table.updateWithContent(created.id!, {type: 'PANEL'} as any),
+    ).rejects.toThrow('Unsupported type')
+  })
+})

--- a/src/datalayer/_tests/DashboardConfigurationTable.ts
+++ b/src/datalayer/_tests/DashboardConfigurationTable.ts
@@ -1,0 +1,18 @@
+import {Kysely} from 'kysely'
+import {AbstractJSONTable} from '../AbstractJSONTable'
+import {DatabaseSchema} from '../entities'
+import {IJSONContent} from '../IJSONContent'
+
+export interface DashboardConfiguration extends IJSONContent {
+  title: string
+  description: string
+  panelsIds: number[]
+  variables: Record<string, unknown>
+  type: 'DASHBOARD'
+}
+
+export class DashboardConfigurationTable extends AbstractJSONTable<'dashboard_configuration', DashboardConfiguration> {
+  constructor(database: Kysely<DatabaseSchema>) {
+    super(database, 'dashboard_configuration', ['DASHBOARD'])
+  }
+}

--- a/src/datalayer/entities.ts
+++ b/src/datalayer/entities.ts
@@ -35,10 +35,17 @@ export interface RequestDataCacheTable extends BaseTable {
     expired: boolean | number | null
 }
 
+// @Todo: DashboardConfigurationTable is just for testing, refactor it
+export interface DashboardConfigurationTable extends BaseTable {
+    type: string
+    content: unknown
+}
+
 // @Todo: this DatabaseSchema is just for testing, refactor it, next-crud API user will provide their own schema
 export interface DatabaseSchema {
     users: UsersTable
     request_data_cache: RequestDataCacheTable
+    dashboard_configuration: DashboardConfigurationTable
 }
 
 export enum ColumnType {


### PR DESCRIPTION
## Summary
- add AbstractJSONTable with flattened JSON content handling via IJSONContent
- update test DashboardConfiguration table and tests
- validate allowed types and cover listing, update and error cases

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1f88aba7c832dabb773d334852944