### PR TITLE
feat: add JSON table handler

### DIFF
--- a/src/servicelayer/JSONTableDataHandler.test.ts
+++ b/src/servicelayer/JSONTableDataHandler.test.ts
@@ -1,0 +1,135 @@
+import type {NextApiRequest, NextApiResponse} from 'next'
+import {Kysely, SqliteDialect} from 'kysely'
+import BetterSqlite3 from 'better-sqlite3'
+import {DatabaseSchema} from '@datalayer/entities'
+import {JSONTableDataHandler} from '@servicelayer/JSONTableDataHandler'
+import {DashboardConfigurationTable, DashboardConfiguration} from '@datalayer/_tests/DashboardConfigurationTable'
+
+// Helper to create mock Next.js request/response objects
+function createMock(method: string, body: any = {}, query: any = {}) {
+    const req = {method, body, query} as unknown as NextApiRequest
+    const res: any = {
+        statusCode: 0,
+        data: undefined as any,
+        status(code: number) {
+            this.statusCode = code
+            return this
+        },
+        json(payload: any) {
+            this.data = payload
+            return this
+        },
+        end() {
+            return this
+        },
+        setHeader() {
+            /* no-op for tests */
+        },
+        statusMessage: '',
+    }
+    return {req, res: res as NextApiResponse}
+}
+
+let db: Kysely<DatabaseSchema>
+
+class DashboardHandler extends JSONTableDataHandler<'dashboard_configuration', DashboardConfiguration> {
+    protected getDb(): Promise<Kysely<DatabaseSchema>> {
+        return Promise.resolve(db)
+    }
+
+    protected async getTable(): Promise<DashboardConfigurationTable> {
+        const repo = new DashboardConfigurationTable(await this.getDb())
+        await repo.ensureSchema()
+        return repo
+    }
+}
+
+describe('JSONTableDataHandler CRUD flow', () => {
+    beforeEach(() => {
+        const sqlite = new BetterSqlite3(':memory:')
+        db = new Kysely<DatabaseSchema>({dialect: new SqliteDialect({database: sqlite})})
+    })
+
+    afterEach(async () => {
+        await db.destroy()
+    })
+
+    test('creates a dashboard configuration', async () => {
+        expect.assertions(3)
+        const {req, res} = createMock('POST', {
+            type: 'DASHBOARD',
+            title: 'Main',
+            description: 'example',
+            panelsIds: [],
+            variables: {},
+        })
+        await new DashboardHandler(req, res).handle()
+        expect(res.statusCode).toBe(200)
+        const created = (res as any).data[0] as DashboardConfiguration
+        expect(created).toMatchObject({title: 'Main'})
+
+        const repo = new DashboardConfigurationTable(db)
+        await repo.ensureSchema()
+        const inDb = await repo.getByIdWithContent(created.id!)
+        expect(inDb?.title).toBe('Main')
+    })
+
+    test('fetches a dashboard configuration', async () => {
+        expect.assertions(2)
+        const repo = new DashboardConfigurationTable(db)
+        await repo.ensureSchema()
+        const created = await repo.createWithContent({
+            type: 'DASHBOARD',
+            title: 'Dash',
+            description: 'd',
+            panelsIds: [],
+            variables: {},
+        })
+
+        const {req, res} = createMock('GET', undefined, {id: String(created.id)})
+        await new DashboardHandler(req, res).handle()
+        expect(res.statusCode).toBe(200)
+        expect((res as any).data[0]).toMatchObject({id: created.id, title: 'Dash'})
+    })
+
+    test('updates a dashboard configuration', async () => {
+        expect.assertions(3)
+        const repo = new DashboardConfigurationTable(db)
+        await repo.ensureSchema()
+        const created = await repo.createWithContent({
+            type: 'DASHBOARD',
+            title: 'Old',
+            description: 'before',
+            panelsIds: [],
+            variables: {},
+        })
+
+        const {req, res} = createMock('PATCH', {id: created.id, description: 'after'})
+        await new DashboardHandler(req, res).handle()
+        expect(res.statusCode).toBe(200)
+        const updated = await repo.getByIdWithContent(created.id!)
+        expect(updated?.description).toBe('after')
+        expect((res as any).data[0].description).toBe('after')
+    })
+
+    test('deletes a dashboard configuration', async () => {
+        expect.assertions(3)
+        const repo = new DashboardConfigurationTable(db)
+        await repo.ensureSchema()
+        const created = await repo.createWithContent({
+            type: 'DASHBOARD',
+            title: 'ToDelete',
+            description: 'd',
+            panelsIds: [],
+            variables: {},
+        })
+
+        const {req, res} = createMock('DELETE', {id: created.id})
+        await new DashboardHandler(req, res).handle()
+        expect(res.statusCode).toBe(200)
+        const deleted = await repo.getByIdWithContent(created.id!)
+        expect(deleted).toBeUndefined()
+        expect((res as any).data[0].id).toBe(created.id)
+    })
+})
+

--- a/src/servicelayer/JSONTableDataHandler.ts
+++ b/src/servicelayer/JSONTableDataHandler.ts
@@ -1,0 +1,111 @@
+import {Kysely} from 'kysely'
+import {BaseHandler, ErrorCode, ResponseError} from './BaseHandler'
+import {DatabaseSchema} from '@datalayer/entities'
+import {AbstractJSONTable} from '@datalayer/AbstractJSONTable'
+import {IJSONContent} from '@datalayer/IJSONContent'
+import {ensureValidId} from '@datalayer/utilities'
+
+/**
+ * REST handler for tables based on {@link AbstractJSONTable}. Works similarly
+ * to {@link BaseTableDataHandler} but operates on JSON content objects.
+ */
+export abstract class JSONTableDataHandler<
+    TableName extends keyof DatabaseSchema,
+    Content extends IJSONContent,
+> extends BaseHandler<Content[]> {
+    /**
+     * Subclasses must return a repository instance for the table they manage.
+     */
+    protected abstract getTable(): Promise<AbstractJSONTable<TableName, Content>>
+
+    /**
+     * Subclasses must return the Kysely instance used for database operations.
+     */
+    protected abstract getDb(): Promise<Kysely<DatabaseSchema>>
+
+    // ----- GET: fetch list or single row by id
+    protected async get(params: Record<string, string>): Promise<void> {
+        const table = await this.getTable()
+
+        if (params['id'] !== undefined) {
+            const id = Number(params['id'])
+            if (!Number.isInteger(id)) {
+                throw new ResponseError(ErrorCode.BAD_REQUEST, 'Invalid id')
+            }
+
+            const row = await table.getByIdWithContent(id)
+            if (row) {
+                this.ok(await this.postGet([row]))
+            } else {
+                this.error(ErrorCode.NOT_FOUND)
+            }
+            return
+        }
+
+        const list = await table.listWithContent()
+        this.ok(await this.postGet(list))
+    }
+
+    // ----- POST: create new content row
+    protected async post(body: Content): Promise<void> {
+        const table = await this.getTable()
+        const created = await table.createWithContent(body)
+        await this.postProcess(await this.getDb())
+        this.ok([created])
+    }
+
+    // ----- PATCH: update existing content or priority
+    protected async patch(body: Partial<Content> & {id: number}): Promise<void> {
+        const table = await this.getTable()
+        ensureValidId(body.id)
+
+        let updated: Content | undefined
+        if (
+            typeof (body as any).priority === 'number' &&
+            Object.keys(body).length === 2
+        ) {
+            await table.updatePriority(body.id, (body as any).priority)
+            updated = await table.getByIdWithContent(body.id)
+        } else {
+            const {id, ...rest} = body as any
+            updated = await table.updateWithContent(id, rest)
+        }
+
+        if (updated) {
+            await this.postProcess(await this.getDb())
+            this.ok([updated])
+        } else {
+            this.error(ErrorCode.NOT_FOUND)
+        }
+    }
+
+    // ----- DELETE: soft delete
+    protected async delete(body: {id: number}): Promise<void> {
+        const table = await this.getTable()
+        ensureValidId(body.id)
+
+        const deleted = await table.delete(body.id)
+        if (deleted) {
+            await this.postProcess(await this.getDb())
+            const content = await table.getByIdWithContent(body.id, {includeDeleted: true})
+            if (content) {
+                this.ok([content])
+            } else {
+                this.ok([])
+            }
+        } else {
+            this.error(ErrorCode.NOT_FOUND)
+        }
+    }
+
+    // ----- Hooks for subclasses -------------------------------------------------
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    protected async postProcess(db: Kysely<DatabaseSchema>): Promise<void> {
+        // Default: no-op
+    }
+
+    protected async postGet(result: Content[]): Promise<Content[]> {
+        return result
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement JSONTableDataHandler for AbstractJSONTable
- add CRUD tests using DashboardConfigurationTable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a206730024832d8390b12a8eca1248