### PR TITLE
docs: add basic API usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,55 @@ Reusable TypeScript repository layer built on [Kysely](https://github.com/kysely
 - [ ] (TODO) DatabaseService that provides a single point of access to the database
 - [ ] (TODO) BaseTableDataHandler that provided REST API for a given table
 
+## Basic API Usage
+
+### AbstractJSONTable
+
+Store typed JSON content while keeping `id`, `priority`, and `type` columns.
+
+```ts
+class DashboardTable extends AbstractJSONTable<'dashboard_configuration', Dashboard> {
+  constructor(db: Kysely<DatabaseSchema>) {
+    super(db, 'dashboard_configuration', ['DASHBOARD'])
+  }
+}
+
+const repo = new DashboardTable(db)
+await repo.ensureSchema()
+const created = await repo.createWithContent({type: 'DASHBOARD', title: 'Main'})
+const fetched = await repo.getByIdWithContent(created.id!)
+```
+
+### JSONTableDataHandler
+
+Next.js handler that wraps an `AbstractJSONTable` and exposes CRUD endpoints.
+
+```ts
+class DashboardHandler extends JSONTableDataHandler<'dashboard_configuration', Dashboard> {
+  protected getDb() { return db }
+  protected async getTable() { return new DashboardTable(db) }
+}
+
+export default (req: NextApiRequest, res: NextApiResponse) =>
+  new DashboardHandler(req, res).handle()
+```
+
+### AbstractCacheTable
+
+Simple cache table with TTL helpers.
+
+```ts
+class RequestCache extends AbstractCacheTable<'request_data_cache'> {
+  constructor(db: Kysely<DatabaseSchema>) {
+    super(db, 'request_data_cache')
+  }
+}
+
+const cache = new RequestCache(db)
+await cache.save({type: 'SESSION'}, {userId: 1})
+const data = await cache.get<{userId: number}>({type: 'SESSION'}, TTL.ONE_DAY)
+```
+
 ## Known Issues
 - priority does not properly work, do not fix it right now, it will be fixed later
 


### PR DESCRIPTION
## Summary
- document AbstractJSONTable with example usage
- show JSONTableDataHandler integration in a Next.js API route
- add AbstractCacheTable cache example with TTL

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a20a193df8832d915ac055898015f6