### PR TITLE
Enable optional Postgres backend for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint .",
-    "test": "jest"
+    "test": "jest",
+    "test:pg": "USE_PG_TESTS=1 jest"
   },
   "dependencies": {
     "better-sqlite3": "^12.2.0",

--- a/src/datalayer/_tests/AbstractJSONTable.test.ts
+++ b/src/datalayer/_tests/AbstractJSONTable.test.ts
@@ -1,6 +1,6 @@
-import {Kysely, SqliteDialect} from 'kysely'
-import BetterSqlite3 from 'better-sqlite3'
+import {Kysely} from 'kysely'
 import {DatabaseSchema} from '../entities'
+import {createTestDb} from '../../testDb'
 import {DashboardConfigurationTable, DashboardConfiguration} from './DashboardConfigurationTable'
 
 describe('AbstractJSONTable', () => {
@@ -8,8 +8,7 @@ describe('AbstractJSONTable', () => {
   let table: DashboardConfigurationTable
 
   beforeEach(async () => {
-    const sqlite = new BetterSqlite3(':memory:')
-    db = new Kysely<DatabaseSchema>({dialect: new SqliteDialect({database: sqlite})})
+    db = await createTestDb()
     table = new DashboardConfigurationTable(db)
     await table.ensureSchema()
   })

--- a/src/datalayer/_tests/users.test.ts
+++ b/src/datalayer/_tests/users.test.ts
@@ -1,15 +1,14 @@
-import {Kysely, SqliteDialect} from 'kysely'
-import BetterSqlite3 from 'better-sqlite3'
+import {Kysely} from 'kysely'
 import {UsersRepository} from "./UsersRepository";
 import {DatabaseSchema} from "../entities";
+import {createTestDb} from '../../testDb'
 
 describe('UsersRepository CRUD', () => {
     let db: Kysely<DatabaseSchema>
     let repo: UsersRepository
 
     beforeEach(async () => {
-        const sqlite = new BetterSqlite3(':memory:')
-        db = new Kysely<DatabaseSchema>({dialect: new SqliteDialect({database: sqlite})})
+        db = await createTestDb()
         repo = new UsersRepository(db)
         await repo.ensureSchema()
     })

--- a/src/servicelayer/BaseTableDataHandler.test.ts
+++ b/src/servicelayer/BaseTableDataHandler.test.ts
@@ -1,9 +1,9 @@
 import type {NextApiRequest, NextApiResponse} from 'next'
-import {Kysely, SqliteDialect} from "kysely"
+import {Kysely} from "kysely"
 import {DatabaseSchema} from "@datalayer/entities"
-import BetterSqlite3 from "better-sqlite3";
 import {BaseTableDataHandler} from "@servicelayer/BaseTableDataHandler";
 import {UsersRepository} from "@datalayer/_tests/UsersRepository";
+import {createTestDb} from "../testDb"
 
 // Simple helper to create mock Next.js request/response objects
 function createMock(method: string, body: any = {}, query: any = {}) {
@@ -50,12 +50,9 @@ class UsersHandler extends BaseTableDataHandler<'users'> {
 }
 
 describe('BaseTableDataHandler REST flow', () => {
-    beforeEach(() => {
-        // Each test gets a fresh in-memory database using BetterSqlite3. The
-        // handler will reuse this instance for the duration of the test so that
-        // data written in earlier requests can be read by later ones.
-        const sqlite = new BetterSqlite3(':memory:')
-        db = new Kysely<DatabaseSchema>({dialect: new SqliteDialect({database: sqlite})})
+    beforeEach(async () => {
+        // Each test gets a fresh database instance.
+        db = await createTestDb()
     })
 
     afterEach(async () => {

--- a/src/servicelayer/JSONTableDataHandler.test.ts
+++ b/src/servicelayer/JSONTableDataHandler.test.ts
@@ -1,9 +1,9 @@
 import type {NextApiRequest, NextApiResponse} from 'next'
-import {Kysely, SqliteDialect} from 'kysely'
-import BetterSqlite3 from 'better-sqlite3'
+import {Kysely} from 'kysely'
 import {DatabaseSchema} from '@datalayer/entities'
 import {JSONTableDataHandler} from '@servicelayer/JSONTableDataHandler'
 import {DashboardConfigurationTable, DashboardConfiguration} from '@datalayer/_tests/DashboardConfigurationTable'
+import {createTestDb} from '../testDb'
 
 // Helper to create mock Next.js request/response objects
 function createMock(method: string, body: any = {}, query: any = {}) {
@@ -45,9 +45,8 @@ class DashboardHandler extends JSONTableDataHandler<'dashboard_configuration', D
 }
 
 describe('JSONTableDataHandler CRUD flow', () => {
-    beforeEach(() => {
-        const sqlite = new BetterSqlite3(':memory:')
-        db = new Kysely<DatabaseSchema>({dialect: new SqliteDialect({database: sqlite})})
+    beforeEach(async () => {
+        db = await createTestDb()
     })
 
     afterEach(async () => {

--- a/src/testDb.ts
+++ b/src/testDb.ts
@@ -1,0 +1,39 @@
+import { Kysely, SqliteDialect, PostgresDialect, sql } from 'kysely'
+import type { DatabaseSchema } from './datalayer/entities'
+
+/**
+ * Create a Kysely instance for tests.
+ *
+ * By default an in-memory SQLite database is used. If the USE_PG_TESTS flag is
+ * truthy, a Postgres database running on localhost:5435 with the
+ * credentials `test_user`/`password` and database `test_db` is used instead.
+ * The connection operates inside the "test" schema which is dropped and
+ * recreated for every invocation.
+ */
+export async function createTestDb(): Promise<Kysely<DatabaseSchema>> {
+  const usePg = !!process.env.USE_PG_TESTS
+  if (usePg) {
+    const { Pool } = await import('pg')
+    const dialect = new PostgresDialect({
+      pool: new Pool({
+        host: 'localhost',
+        port: 5435,
+        user: 'test_user',
+        password: 'password',
+        database: 'test_db'
+      })
+    })
+    const db = new Kysely<DatabaseSchema>({ dialect })
+    // Ensure a clean test schema for each run
+    await sql`DROP SCHEMA IF EXISTS test CASCADE`.execute(db)
+    await sql`CREATE SCHEMA test`.execute(db)
+    await sql`SET search_path TO test`.execute(db)
+    return db
+  }
+
+  const { default: BetterSqlite3 } = await import('better-sqlite3')
+  const sqlite = new BetterSqlite3(':memory:')
+  return new Kysely<DatabaseSchema>({
+    dialect: new SqliteDialect({ database: sqlite })
+  })
+}


### PR DESCRIPTION
## Summary
- add createTestDb helper that conditionally connects to Postgres using `USE_PG_TESTS`, resetting a `test` schema
- refactor tests to use the helper so they can run on SQLite or Postgres
- add `test:pg` npm script for running tests against Postgres
- remove `DATABASE_URL` dependency and hardcode connection parameters for Postgres tests

## Testing
- `npm test`
- `npm run lint`
- `npm run test:pg` *(fails: AggregateError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a21c7714b0832d878a625d65107a7c