### PR TITLE
Allow custom data schema in table and handler generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Reusable TypeScript repository layer built on [Kysely](https://github.com/kysely
 Store typed JSON content while keeping `id`, `priority`, and `type` columns.
 
 ```ts
-class DashboardTable extends AbstractJSONTable<'dashboard_configuration', Dashboard> {
+class DashboardTable extends AbstractJSONTable<DatabaseSchema, 'dashboard_configuration', Dashboard> {
   constructor(db: Kysely<DatabaseSchema>) {
     super(db, 'dashboard_configuration', ['DASHBOARD'])
   }
@@ -35,7 +35,7 @@ const fetched = await repo.getByIdWithContent(created.id!)
 Next.js handler that wraps an `AbstractJSONTable` and exposes CRUD endpoints.
 
 ```ts
-class DashboardHandler extends JSONTableDataHandler<'dashboard_configuration', Dashboard> {
+class DashboardHandler extends JSONTableDataHandler<DatabaseSchema, 'dashboard_configuration', Dashboard> {
   protected getDb() { return db }
   protected async getTable() { return new DashboardTable(db) }
 }
@@ -49,7 +49,7 @@ export default (req: NextApiRequest, res: NextApiResponse) =>
 Simple cache table with TTL helpers.
 
 ```ts
-class RequestCache extends AbstractCacheTable<'request_data_cache'> {
+class RequestCache extends AbstractCacheTable<DatabaseSchema, 'request_data_cache'> {
   constructor(db: Kysely<DatabaseSchema>) {
     super(db, 'request_data_cache')
   }

--- a/src/datalayer/RequestDataRepository.ts
+++ b/src/datalayer/RequestDataRepository.ts
@@ -16,7 +16,7 @@ export interface CacheEntry<T> extends CacheEntryKey {
     expired: boolean | number | null
 }
 
-export default class RequestDataRepository extends AbstractCacheTable<'request_data_cache'> {
+export default class RequestDataRepository extends AbstractCacheTable<DatabaseSchema, 'request_data_cache'> {
     constructor(db: Kysely<DatabaseSchema>) {
         super(db, 'request_data_cache')
     }

--- a/src/datalayer/_tests/DashboardConfigurationTable.ts
+++ b/src/datalayer/_tests/DashboardConfigurationTable.ts
@@ -11,7 +11,7 @@ export interface DashboardConfiguration extends IJSONContent {
   type: 'DASHBOARD'
 }
 
-export class DashboardConfigurationTable extends AbstractJSONTable<'dashboard_configuration', DashboardConfiguration> {
+export class DashboardConfigurationTable extends AbstractJSONTable<DatabaseSchema, 'dashboard_configuration', DashboardConfiguration> {
   constructor(database: Kysely<DatabaseSchema>) {
     super(database, 'dashboard_configuration', ['DASHBOARD'])
   }

--- a/src/datalayer/_tests/UsersRepository.ts
+++ b/src/datalayer/_tests/UsersRepository.ts
@@ -2,7 +2,7 @@ import {Kysely} from "kysely";
 import {AbstractTable} from "../AbstractTable";
 import {ColumnSpec, ColumnType, DatabaseSchema} from "../entities";
 
-export class UsersRepository extends AbstractTable<'users'> {
+export class UsersRepository extends AbstractTable<DatabaseSchema, 'users'> {
 
     constructor(database: Kysely<DatabaseSchema>) {
         super(database, 'users')

--- a/src/servicelayer/BaseTableDataHandler.test.ts
+++ b/src/servicelayer/BaseTableDataHandler.test.ts
@@ -35,7 +35,7 @@ function createMock(method: string, body: any = {}, query: any = {}) {
 let db: Kysely<DatabaseSchema>
 
 // Handler implementation for tests
-class UsersHandler extends BaseTableDataHandler<'users'> {
+class UsersHandler extends BaseTableDataHandler<DatabaseSchema, 'users'> {
 
     protected getDb(): Promise<Kysely<DatabaseSchema>> {
         // Return the shared database instance created in the test hooks.

--- a/src/servicelayer/JSONTableDataHandler.test.ts
+++ b/src/servicelayer/JSONTableDataHandler.test.ts
@@ -32,7 +32,7 @@ function createMock(method: string, body: any = {}, query: any = {}) {
 
 let db: Kysely<DatabaseSchema>
 
-class DashboardHandler extends JSONTableDataHandler<'dashboard_configuration', DashboardConfiguration> {
+class DashboardHandler extends JSONTableDataHandler<DatabaseSchema, 'dashboard_configuration', DashboardConfiguration> {
     protected getDb(): Promise<Kysely<DatabaseSchema>> {
         return Promise.resolve(db)
     }

--- a/src/servicelayer/JSONTableDataHandler.ts
+++ b/src/servicelayer/JSONTableDataHandler.ts
@@ -1,6 +1,5 @@
 import {Kysely} from 'kysely'
 import {BaseHandler, ErrorCode, ResponseError} from './BaseHandler'
-import {DatabaseSchema} from '@datalayer/entities'
 import {AbstractJSONTable} from '@datalayer/AbstractJSONTable'
 import {IJSONContent} from '@datalayer/IJSONContent'
 import {ensureValidId} from '@datalayer/utilities'
@@ -10,18 +9,19 @@ import {ensureValidId} from '@datalayer/utilities'
  * to {@link BaseTableDataHandler} but operates on JSON content objects.
  */
 export abstract class JSONTableDataHandler<
-    TableName extends keyof DatabaseSchema,
+    DST,
+    TableName extends keyof DST & string,
     Content extends IJSONContent,
 > extends BaseHandler<Content[]> {
     /**
      * Subclasses must return a repository instance for the table they manage.
      */
-    protected abstract getTable(): Promise<AbstractJSONTable<TableName, Content>>
+    protected abstract getTable(): Promise<AbstractJSONTable<DST, TableName, Content>>
 
     /**
      * Subclasses must return the Kysely instance used for database operations.
      */
-    protected abstract getDb(): Promise<Kysely<DatabaseSchema>>
+    protected abstract getDb(): Promise<Kysely<DST>>
 
     // ----- GET: fetch list or single row by id
     protected async get(params: Record<string, string>): Promise<void> {
@@ -100,7 +100,7 @@ export abstract class JSONTableDataHandler<
 
     // ----- Hooks for subclasses -------------------------------------------------
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    protected async postProcess(db: Kysely<DatabaseSchema>): Promise<void> {
+    protected async postProcess(db: Kysely<DST>): Promise<void> {
         // Default: no-op
     }
 


### PR DESCRIPTION
## Summary
- generalize AbstractCacheTable, BaseTableDataHandler, and JSONTableDataHandler to accept a DataSchema generic
- update repositories, tests, and docs to provide the schema when extending tables
- document new API usage for custom schema types

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a37e80f1cc832d8ab31f9be049042e