### PR TITLE
Allow nullable priorities without unique constraint

### DIFF
--- a/src/datalayer/_tests/AbstractJSONTable.test.ts
+++ b/src/datalayer/_tests/AbstractJSONTable.test.ts
@@ -27,10 +27,25 @@ describe('AbstractJSONTable', () => {
     }
     const created = await table.createWithContent(config)
     expect(created.id).toBeDefined()
-    expect(created).toMatchObject({...config, priority: 0})
+    expect(created).toMatchObject({...config, priority: created.id})
 
     const fetched = await table.getByIdWithContent(created.id!)
     expect(fetched).toEqual(created)
+  })
+
+  test('create with explicit priority', async () => {
+    const config: DashboardConfiguration = {
+      type: 'DASHBOARD',
+      title: 'With priority',
+      description: 'example',
+      panelsIds: [],
+      variables: {},
+      priority: 5,
+    }
+    const created = await table.createWithContent(config)
+    expect(created).toMatchObject(config)
+    expect(created.id).toBeDefined()
+    expect(created.id).not.toBe(config.priority)
   })
 
   test('listWithContent returns all rows', async () => {

--- a/src/datalayer/_tests/users.test.ts
+++ b/src/datalayer/_tests/users.test.ts
@@ -20,7 +20,7 @@ describe('UsersRepository CRUD', () => {
     test('create and read user', async () => {
         const created = await repo.create({name: 'John', surname: 'Doe', telephone_number: '123'})
         const fetched = await repo.getById(created.id)
-        expect(fetched).toMatchObject({name: 'John', surname: 'Doe', telephone_number: '123', priority: 0})
+        expect(fetched).toMatchObject({name: 'John', surname: 'Doe', telephone_number: '123', priority: created.id})
     })
 
     test('update user', async () => {

--- a/src/datalayer/utilities.ts
+++ b/src/datalayer/utilities.ts
@@ -26,13 +26,13 @@ export function addIdColumn<T extends DatabaseSchema>(
     return builder.addColumn('id', 'integer', (col) => col.primaryKey().autoIncrement())
 }
 
-// Create a unique index on priority in a portable way
-export async function createUniquePriorityIndex<T extends DatabaseSchema>(
+// Create a non-unique index on priority in a portable way
+export async function createPriorityIndex<T extends DatabaseSchema>(
     db: Kysely<T>,
     tableName: keyof T
 ) {
-    const indexName = `${String(tableName)}_priority_key`
-    await sql`CREATE UNIQUE INDEX IF NOT EXISTS ${sql.raw(indexName)} ON ${sql.raw(
+    const indexName = `${String(tableName)}_priority_idx`
+    await sql`CREATE INDEX IF NOT EXISTS ${sql.raw(indexName)} ON ${sql.raw(
             String(tableName)
     )} (priority)`.execute(db)
 }


### PR DESCRIPTION
## Summary
- ensure provided priorities are valid positive integers, default invalid values to null
- allow duplicate priorities by removing uniqueness constraint and consolidating nulls to their row IDs
- add regression test verifying explicit priority is preserved and ID is distinct

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a0f8a8dc832d97815bcaf3aae644