### PR TITLE
Refactor cache to single extensible table

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,18 +46,19 @@ export default (req: NextApiRequest, res: NextApiResponse) =>
 
 ### AbstractCacheTable
 
-Simple cache table with TTL helpers. Pass a table name or an object to enable features.
+Simple cache table with TTL helpers and existence checks.
 
 ```ts
 class RequestCache extends AbstractCacheTable<DatabaseSchema, 'request_data_cache'> {
   constructor(db: Kysely<DatabaseSchema>) {
-    super(db, { tableName: 'request_data_cache', softDelete: true, hasPriority: true }) // or super(db, 'request_data_cache')
+    super(db, 'request_data_cache')
   }
 }
 
 const cache = new RequestCache(db)
-await cache.save({type: 'SESSION'}, {userId: 1})
-const data = await cache.get<{userId: number}>({type: 'SESSION'}, TTL.ONE_DAY)
+await cache.save({key: 'session1', type: 'SESSION'}, {userId: 1})
+const exists = await cache.isCached({key: 'session1'}, TTL.ONE_DAY)
+const data = await cache.getLast<{userId: number}>({key: 'session1'}, TTL.ONE_DAY)
 ```
 
 ## Known Issues

--- a/src/datalayer/RequestDataRepository.ts
+++ b/src/datalayer/RequestDataRepository.ts
@@ -1,125 +1,18 @@
-import {Kysely, sql} from 'kysely'
-import {AbstractCacheTable, TTL} from "@datalayer/AbstractCacheTable";
-import {ColumnSpec, ColumnType, DatabaseSchema} from "@datalayer/entities";
-
-export interface CacheEntryKey {
-    requestUrl: string
-    type: string
-    reference?: string
-}
-
-export interface CacheEntry<T> extends CacheEntryKey {
-    id: number
-    data: T
-    metadata: any
-    createdAt: Date
-    expired: boolean | number | null
-}
+import {Kysely} from 'kysely'
+import {AbstractCacheTable, TTL, CacheEntry} from '@datalayer/AbstractCacheTable'
+import {ColumnSpec, ColumnType, DatabaseSchema} from '@datalayer/entities'
 
 export default class RequestDataRepository extends AbstractCacheTable<DatabaseSchema, 'request_data_cache'> {
     constructor(db: Kysely<DatabaseSchema>) {
-        super(db, {tableName: 'request_data_cache', softDelete: true, hasPriority: true})
+        super(db, 'request_data_cache')
     }
-
-    private priorityCounter = 0
 
     protected extraColumns(): ColumnSpec[] {
         return [
-            {name: 'request_url', type: ColumnType.STRING, notNull: true},
             {name: 'reference', type: ColumnType.STRING},
             {name: 'metadata', type: ColumnType.JSON},
-            ...super.extraColumns(),
         ]
-    }
-
-    protected applyKeyFilters<T extends { where: any }>(qb: T, select: Partial<CacheEntryKey>): T {
-        let out: any = qb
-        if (select.requestUrl !== undefined) out = out.where('request_url', '=', select.requestUrl)
-        if (select.type !== undefined) out = out.where('type', '=', select.type)
-        if (select.reference !== undefined) out = out.where('reference', '=', select.reference)
-        return out
-    }
-
-    async get<T>(select: Partial<CacheEntryKey>, ttl?: TTL): Promise<T | null> {
-        this.ensureSelectNotEmpty(select)
-        let qb = this.applyKeyFilters(
-            this.db.selectFrom(this.tableName as string).select(['data']),
-            select,
-        )
-        qb = this.applyTtlFilters(qb, ttl ?? TTL.NOT_EXPIRED)
-            .orderBy('created_at', 'desc')
-            .orderBy('id', 'desc')
-            .limit(1)
-        const row = await qb.executeTakeFirst()
-        if (!row) return null
-        return this.decodeJson<T>((row as any).data)
-    }
-
-    async getAll<T>(select: Partial<CacheEntryKey>, ttl?: TTL): Promise<CacheEntry<T>[]> {
-        this.ensureSelectNotEmpty(select)
-        let qb = this.applyKeyFilters(
-            this.db
-                .selectFrom(this.tableName as string)
-                .select(['id', 'data', 'metadata', 'created_at', 'request_url', 'reference', 'type', 'expired']),
-            select,
-        )
-        qb = this.applyTtlFilters(qb, ttl ?? TTL.NOT_EXPIRED)
-            .orderBy('created_at', 'desc')
-            .orderBy('id', 'desc')
-        const rows = await qb.execute()
-        return rows.map((r: any) => ({
-            id: r.id,
-            requestUrl: r.request_url,
-            reference: r.reference ?? undefined,
-            type: r.type,
-            data: this.decodeJson<T>(r.data),
-            metadata: this.decodeJson<any>(r.metadata),
-            createdAt: this.asDate(r.created_at),
-            expired: r.expired,
-        }))
-    }
-
-    async save<T>(key: CacheEntryKey, data: T, metadata: object = {}): Promise<boolean> {
-        if (data === undefined || data === null) return false
-        const values = {
-            request_url: key.requestUrl,
-            reference: key.reference ?? null,
-            type: key.type,
-            data: this.encodeJson(data),
-            metadata: this.encodeJsonOrNull(metadata),
-            created_at: sql`CURRENT_TIMESTAMP`,
-            expired: this.expiredValue(false),
-            priority: this.priorityCounter++,
-        }
-        try {
-            await this.db
-                .insertInto(this.tableName as string)
-                .values(values as any)
-                .returning(['id'])
-                .executeTakeFirst()
-            return true
-        } catch {
-            try {
-                await this.db
-                    .insertInto(this.tableName as string)
-                    .values(values as any)
-                    .executeTakeFirst()
-                return true
-            } catch (e2) {
-                console.error('Error in save:', e2)
-                return false
-            }
-        }
-    }
-
-    async expireEntries(select: Partial<CacheEntryKey>, ttl: TTL): Promise<number> {
-        // Cast is safe: base implementation will ignore extra fields via applyKeyFilters override
-        return super.expireEntries(select as any, ttl)
-    }
-
-    async cleanExpiredEntries(select: Partial<CacheEntryKey>): Promise<number> {
-        return super.cleanExpiredEntries(select as any)
     }
 }
 
-export {TTL}
+export {TTL, CacheEntry}

--- a/src/datalayer/entities.ts
+++ b/src/datalayer/entities.ts
@@ -25,14 +25,20 @@ export interface UsersTable extends BaseTable {
     telephone_number: string
 }
 
-// @Todo: RequestDataCacheTable is just for testing, refactor it
-export interface RequestDataCacheTable extends BaseTable {
-    request_url: string
-    reference: string | null
+// Base structure for cache tables used in tests
+export interface CacheBaseTable {
+    id: Generated<number>
+    key: string
     type: string
-    data: unknown
-    metadata: unknown | null
+    content: unknown
     expired: boolean | number | null
+    created_at: TimestampDefault
+}
+
+// @Todo: RequestDataCacheTable is just for testing, refactor it
+export interface RequestDataCacheTable extends CacheBaseTable {
+    reference: string | null
+    metadata: unknown | null
 }
 
 // @Todo: DashboardConfigurationTable is just for testing, refactor it


### PR DESCRIPTION
## Summary
- replace duplicated cache repositories with a single AbstractCacheTable
- allow cache implementations to define extra columns (e.g. reference, metadata)
- add getLast, getLastOfType, and isCached helpers for TTL-aware cache lookups

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5ec91ed64832dac7af651751671c5