### PR TITLE
bugfix: validate id is integer

### DIFF
--- a/src/datalayer/_tests/users.test.ts
+++ b/src/datalayer/_tests/users.test.ts
@@ -48,6 +48,10 @@ describe('UsersRepository CRUD', () => {
         expect(fetched).toBeUndefined()
     })
 
+    test('getById rejects non-integer id', async () => {
+        await expect(repo.getById(1.5)).rejects.toThrow('Invalid id')
+    })
+
     // This test does not work. Disabling for now.
     xtest('update priority shifts others', async () => {
         const u1 = await repo.create({name: 'A', surname: 'A', telephone_number: '1', priority: 0})

--- a/src/datalayer/utilities.ts
+++ b/src/datalayer/utilities.ts
@@ -2,8 +2,8 @@ import {DatabaseSchema, SupportedDialect} from "./entities";
 import {Kysely, sql} from "kysely";
 
 export function ensureValidId(id: unknown): asserts id is number {
-    if (typeof id !== 'number' || !Number.isFinite(id) || id <= 0) {
-        throw new Error('Invalid id: must be a finite number > 0')
+    if (typeof id !== 'number' || !Number.isFinite(id) || !Number.isInteger(id) || id <= 0) {
+        throw new Error('Invalid id: must be a finite integer > 0')
     }
 }
 


### PR DESCRIPTION
## Summary
- validate id values are finite integers
- test non-integer id rejects in UsersRepository

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5fa15906c832d929f27a02422cd7d