### PR TITLE
feat: share request mock helper across servicelayer tests

### DIFF
--- a/src/servicelayer/BaseTableDataHandler.test.ts
+++ b/src/servicelayer/BaseTableDataHandler.test.ts
@@ -1,34 +1,9 @@
-import type {NextApiRequest, NextApiResponse} from 'next'
 import {Kysely} from "kysely"
 import {DatabaseSchema} from "@datalayer/entities"
 import {BaseTableDataHandler} from "@servicelayer/BaseTableDataHandler";
 import {UsersRepository} from "@datalayer/_tests/UsersRepository";
 import {createTestDb} from "../testDb"
-
-// Simple helper to create mock Next.js request/response objects
-function createMock(method: string, body: any = {}, query: any = {}) {
-    const req = {method, body, query} as unknown as NextApiRequest
-    const res: any = {
-        statusCode: 0,
-        data: undefined as any,
-        status(code: number) {
-            this.statusCode = code
-            return this
-        },
-        json(payload: any) {
-            this.data = payload
-            return this
-        },
-        end() {
-            return this
-        },
-        setHeader() {
-            /* no-op for tests */
-        },
-        statusMessage: '',
-    }
-    return {req, res: res as NextApiResponse}
-}
+import {createMock} from '@servicelayer/testUtils'
 
 // We'll reuse the same in-memory database instance for each handler call so
 // that data persists across multiple requests within a test case.

--- a/src/servicelayer/JSONTableDataHandler.test.ts
+++ b/src/servicelayer/JSONTableDataHandler.test.ts
@@ -1,34 +1,9 @@
-import type {NextApiRequest, NextApiResponse} from 'next'
 import {Kysely} from 'kysely'
 import {DatabaseSchema} from '@datalayer/entities'
 import {JSONTableDataHandler} from '@servicelayer/JSONTableDataHandler'
 import {DashboardConfigurationTable, DashboardConfiguration} from '@datalayer/_tests/DashboardConfigurationTable'
 import {createTestDb} from '../testDb'
-
-// Helper to create mock Next.js request/response objects
-function createMock(method: string, body: any = {}, query: any = {}) {
-    const req = {method, body, query} as unknown as NextApiRequest
-    const res: any = {
-        statusCode: 0,
-        data: undefined as any,
-        status(code: number) {
-            this.statusCode = code
-            return this
-        },
-        json(payload: any) {
-            this.data = payload
-            return this
-        },
-        end() {
-            return this
-        },
-        setHeader() {
-            /* no-op for tests */
-        },
-        statusMessage: '',
-    }
-    return {req, res: res as NextApiResponse}
-}
+import {createMock} from '@servicelayer/testUtils'
 
 let db: Kysely<DatabaseSchema>
 

--- a/src/servicelayer/testUtils.ts
+++ b/src/servicelayer/testUtils.ts
@@ -1,0 +1,25 @@
+import type {NextApiRequest, NextApiResponse} from 'next'
+
+export function createMock(method: string, body: any = {}, query: any = {}) {
+    const req = {method, body, query} as unknown as NextApiRequest
+    const res: any = {
+        statusCode: 0,
+        data: undefined as any,
+        status(code: number) {
+            this.statusCode = code
+            return this
+        },
+        json(payload: any) {
+            this.data = payload
+            return this
+        },
+        end() {
+            return this
+        },
+        setHeader() {
+            // no-op for tests
+        },
+        statusMessage: '',
+    }
+    return {req, res: res as NextApiResponse}
+}


### PR DESCRIPTION
## Summary
- add `createMock` helper for Next.js request/response objects
- use shared helper in servicelayer test suites

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5fa068e6c832da7604c0a1637f585