### PR TITLE
feature: add key-value table abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ Reusable TypeScript repository layer built on [Kysely](https://github.com/kysely
 - [x] Soft delete, hard delete, and restore
 - [x] Stable priority updates that shift other rows
 - [x] Schema management via `ensureSchema()` and `syncColumns()`
+- [x] `BaseTable` abstract class for shared table utilities
 - [x] `AbstractJSONTable` for storing typed JSON content
 - [x] `AbstractCacheTable` for simple cache management with TTL
+- [x] `AbstractKeyValueTable` for simple key/value storage
 
 ## API Usage
 
@@ -47,6 +49,22 @@ const cache = new RequestCache(db)
 await cache.save({key: 'session1', type: 'SESSION'}, {userId: 1})
 const exists = await cache.isCached({key: 'session1'}, TTL.ONE_DAY)
 const data = await cache.getLast<{userId: number}>({key: 'session1'}, TTL.ONE_DAY)
+```
+
+#### AbstractKeyValueTable
+
+Persist simple key/value pairs with typed values.
+
+```ts
+class SettingsTable extends AbstractKeyValueTable<DatabaseSchema, 'settings', string> {
+    constructor(db: Kysely<DatabaseSchema>) {
+        super(db, {tableName: 'settings', valueType: ColumnType.STRING})
+    }
+}
+
+const settings = new SettingsTable(db)
+await settings.setValue('THEME', 'dark')
+const obj = await settings.getObject()
 ```
 
 ### REST handler layer

--- a/src/datalayer/AbstractJSONTable.ts
+++ b/src/datalayer/AbstractJSONTable.ts
@@ -1,5 +1,5 @@
 import {Insertable, Kysely, Selectable, Updateable} from 'kysely'
-import {AbstractTable, BaseTable, TableConfig} from './AbstractTable'
+import {AbstractTable, AbstractTableSchema, TableConfig} from './AbstractTable'
 import {ColumnSpec, ColumnType} from './entities'
 import {IJSONContent} from './IJSONContent'
 
@@ -118,7 +118,7 @@ export abstract class AbstractJSONTable<DST, TableName extends keyof DST & strin
     }
 }
 
-export interface JSONContentBaseTable<T> extends BaseTable {
+export interface JSONContentBaseTable<T> extends AbstractTableSchema {
     type: string
     content: T
 }

--- a/src/datalayer/AbstractKeyValueTable.ts
+++ b/src/datalayer/AbstractKeyValueTable.ts
@@ -1,0 +1,122 @@
+import {Insertable, Kysely, Updateable, sql} from 'kysely'
+import {ColumnType} from './entities'
+import {BaseTable} from './BaseTable'
+
+export interface KeyValueBaseTable<V> {
+    key: string
+    value: V | null
+}
+
+export interface KeyValueTableConfig<TableName extends string> {
+    tableName: TableName
+    valueType: ColumnType
+}
+
+export abstract class AbstractKeyValueTable<
+    DST,
+    TableName extends keyof DST & string,
+    Value
+> extends BaseTable<DST, TableName> {
+    private readonly valueType: ColumnType
+
+    constructor(database: Kysely<DST>, config: KeyValueTableConfig<TableName>) {
+        super(database, config.tableName)
+        this.valueType = config.valueType
+    }
+
+    protected encode(value: Value | null): unknown {
+        if (this.valueType === ColumnType.JSON) {
+            if (value == null) return null
+            return this.dialect === 'postgres' ? value : JSON.stringify(value)
+        }
+        return value as unknown
+    }
+
+    protected decode(value: unknown): Value | null {
+        if (this.valueType === ColumnType.JSON) {
+            if (value == null) return null as any
+            if (this.dialect === 'postgres') return value as Value
+            if (typeof value === 'string') {
+                try {
+                    return JSON.parse(value) as Value
+                } catch {
+                    return value as Value
+                }
+            }
+        }
+        return value as Value | null
+    }
+
+    async ensureSchema(): Promise<void> {
+        let builder = this.db.schema.createTable(this.tableName).ifNotExists()
+        builder = builder.addColumn('key', 'varchar', col => col.notNull())
+        builder = builder.addColumn(
+            'value',
+            this.sqlApi.toStringType(this.valueType) as any,
+        )
+
+        builder = this.applyExtraColumns(builder)
+
+        await builder.execute()
+        const indexName = `${String(this.tableName)}_key_idx`
+        await sql`CREATE INDEX IF NOT EXISTS ${sql.raw(indexName)} ON ${sql.raw(
+            String(this.tableName),
+        )} (key)`.execute(this.db)
+    }
+
+    async getValue(key: string): Promise<Value | null | undefined> {
+        const row = await this.db
+            .selectFrom(this.tableName as string)
+            .select(['value'])
+            .where('key', '=', key)
+            .executeTakeFirst()
+        if (!row) return undefined
+        return this.decode((row as any).value)
+    }
+
+    async setValue(key: string, value: Value | null): Promise<void> {
+        const encoded = this.encode(value)
+        const res = await (this.db.updateTable(this.tableName as string) as any)
+            .set({value: encoded} as Updateable<DST[TableName]>)
+            .where('key', '=', key)
+            .executeTakeFirst()
+        const updated = (res as any)?.numUpdatedRows ?? 0n
+        if (Number(updated) === 0) {
+            await (this.db.insertInto(this.tableName as string) as any)
+                .values({key, value: encoded} as Insertable<DST[TableName]>)
+                .execute()
+        }
+    }
+
+    async getObject(): Promise<Record<string, Value | null>> {
+        const rows = await this.db
+            .selectFrom(this.tableName as string)
+            .select(['key', 'value'])
+            .execute()
+        const result: Record<string, Value | null> = {}
+        for (const row of rows as any[]) {
+            result[row.key] = this.decode(row.value)
+        }
+        return result
+    }
+
+    async setObject(obj: Record<string, Value | null | undefined>): Promise<void> {
+        await this.db.transaction().execute(async trx => {
+            for (const [key, value] of Object.entries(obj)) {
+                if (value === undefined) continue
+                const encoded = this.encode(value as Value | null)
+                const res = await (trx.updateTable(this.tableName as string) as any)
+                    .set({value: encoded} as Updateable<DST[TableName]>)
+                    .where('key', '=', key)
+                    .executeTakeFirst()
+                const updated = (res as any)?.numUpdatedRows ?? 0n
+                if (Number(updated) === 0) {
+                    await (trx.insertInto(this.tableName as string) as any)
+                        .values({key, value: encoded} as Insertable<DST[TableName]>)
+                        .execute()
+                }
+            }
+        })
+    }
+}
+

--- a/src/datalayer/BaseTable.ts
+++ b/src/datalayer/BaseTable.ts
@@ -1,0 +1,52 @@
+import {Kysely, sql} from 'kysely'
+import {ColumnSpec, SupportedDialect} from './entities'
+import {createSqlApi, ISQLApi} from './sqlapi/ISQLApi'
+import {detectDialect} from './utilities'
+
+export abstract class BaseTable<DST, TableName extends keyof DST & string> {
+    protected readonly dialect: SupportedDialect
+    protected readonly sqlApi: ISQLApi
+    protected readonly tableName: TableName
+
+    constructor(protected readonly database: Kysely<DST>, tableName: TableName) {
+        this.tableName = tableName
+        this.dialect = detectDialect(this.database)
+        this.sqlApi = createSqlApi(this.dialect)
+    }
+
+    protected get db(): Kysely<any> {
+        return this.database as unknown as Kysely<any>
+    }
+
+    protected extraColumns(): ColumnSpec[] {
+        return []
+    }
+
+    protected applyExtraColumns<T>(builder: T): T {
+        for (const column of this.extraColumns()) {
+            builder = (builder as any).addColumn(
+                column.name,
+                this.sqlApi.toStringType(column.type) as any,
+                (col: any) => {
+                    if (column.notNull) col = col.notNull()
+                    if (column.unique) col = col.unique()
+                    if (column.defaultSql) col = col.defaultTo(sql.raw(column.defaultSql))
+                    return col
+                },
+            )
+        }
+        return builder
+    }
+
+    abstract ensureSchema(): Promise<void>
+
+    async syncColumns(schemaName: string = 'public'): Promise<void> {
+        await this.sqlApi.syncColumns(
+            this.db,
+            this.tableName as string,
+            this.extraColumns(),
+            schemaName,
+        )
+    }
+}
+

--- a/src/datalayer/_tests_/AbstractKeyValueTable.test.ts
+++ b/src/datalayer/_tests_/AbstractKeyValueTable.test.ts
@@ -1,0 +1,34 @@
+import {Kysely} from 'kysely'
+import {createTestDb, DatabaseSchema, SettingsRepository} from '@datalayer/_tests_/testUtils'
+
+describe('AbstractKeyValueTable', () => {
+    let db: Kysely<DatabaseSchema>
+    let repo: SettingsRepository
+
+    beforeEach(async () => {
+        db = await createTestDb()
+        repo = new SettingsRepository(db)
+        await repo.ensureSchema()
+    })
+
+    afterEach(async () => {
+        await db.destroy()
+    })
+
+    test('setValue and getValue', async () => {
+        await repo.setValue('THEME', 'dark')
+        const val = await repo.getValue('THEME')
+        expect(val).toBe('dark')
+    })
+
+    test('setObject updates multiple keys and handles null/undefined', async () => {
+        await repo.setObject({USER_TOKEN: 'abc', THEME: 'light'})
+        await repo.setObject({USER_TOKEN: null, THEME: undefined, LOCALE: 'en'})
+        expect(await repo.getValue('USER_TOKEN')).toBeNull()
+        expect(await repo.getValue('THEME')).toBe('light')
+        expect(await repo.getValue('LOCALE')).toBe('en')
+        const all = await repo.getObject()
+        expect(all).toEqual({USER_TOKEN: null, THEME: 'light', LOCALE: 'en'})
+    })
+})
+

--- a/src/datalayer/_tests_/testUtils.ts
+++ b/src/datalayer/_tests_/testUtils.ts
@@ -2,9 +2,10 @@ import type {NextApiRequest, NextApiResponse} from 'next'
 import {AbstractCacheTable, CacheBaseTable} from "@datalayer/AbstractCacheTable";
 import {ColumnSpec, ColumnType} from "@datalayer/entities";
 import {Kysely, PostgresDialect, sql, SqliteDialect} from "kysely";
-import {AbstractTable, BaseTable} from "@datalayer/AbstractTable";
+import {AbstractTable, AbstractTableSchema} from "@datalayer/AbstractTable";
 import {IJSONContent} from "@datalayer/IJSONContent";
 import {AbstractJSONTable, JSONContentBaseTable} from "@datalayer/AbstractJSONTable";
+import {AbstractKeyValueTable, KeyValueBaseTable} from "@datalayer/AbstractKeyValueTable";
 import BetterSqlite3 from "better-sqlite3";
 import {Pool} from "pg";
 
@@ -74,12 +75,18 @@ export class DashboardConfigurationRepository extends AbstractJSONTable<Database
     }
 }
 
+export class SettingsRepository extends AbstractKeyValueTable<DatabaseSchema, 'settings', string> {
+    constructor(database: Kysely<DatabaseSchema>) {
+        super(database, {tableName: 'settings', valueType: ColumnType.STRING})
+    }
+}
+
 export interface RequestDataCacheTable extends CacheBaseTable {
     reference: string | null
     metadata: unknown | null
 }
 
-export interface UsersTable extends BaseTable {
+export interface UsersTable extends AbstractTableSchema {
     name: string
     surname: string
     telephone_number: string
@@ -89,6 +96,7 @@ export interface DatabaseSchema {
     users: UsersTable
     request_data_cache: RequestDataCacheTable
     dashboard_configuration: JSONContentBaseTable<DashboardConfiguration>
+    settings: KeyValueBaseTable<string>
 }
 
 /**


### PR DESCRIPTION
## Summary
- introduce BaseTable to centralize dialect detection and extra-column handling
- refactor tables to extend BaseTable and support config-style constructors
- document and demonstrate new AbstractKeyValueTable in README
- rename BaseTableRow interface to AbstractTableSchema for clarity

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a74f415bd0832dbd813d66bd263185