### PR TITLE
feat: rename abstract table classes to repositories

### DIFF
--- a/src/datalayer/AbstractCacheRepository.ts
+++ b/src/datalayer/AbstractCacheRepository.ts
@@ -24,7 +24,7 @@ export interface CacheEntry<T> {
     [extra: string]: any
 }
 
-export abstract class AbstractCacheTable<DST, TableName extends keyof DST & string> extends BaseTable<DST, TableName> {
+export abstract class AbstractCacheRepository<DST, TableName extends keyof DST & string> extends BaseTable<DST, TableName> {
 
     async ensureSchema(): Promise<void> {
         let createBuilder = this.db.schema.createTable(this.tableName).ifNotExists()

--- a/src/datalayer/AbstractJSONRepository.ts
+++ b/src/datalayer/AbstractJSONRepository.ts
@@ -1,14 +1,14 @@
 import {Insertable, Kysely, Selectable, Updateable} from 'kysely'
-import {AbstractTable, AbstractTableSchema, TableConfig} from './AbstractTable'
+import {AbstractRepository, AbstractRepositorySchema, TableConfig} from './AbstractRepository'
 import {ColumnSpec, ColumnType} from './entities'
 import {IJSONContent} from './IJSONContent'
 
 /**
- * Simple JSON storage table backed by a {@link AbstractTable}. Stores arbitrary
+ * Simple JSON storage table backed by a {@link AbstractRepository}. Stores arbitrary
  * JSON in a `content` column while exposing `id`, `type` and `priority` fields
  * directly on the returned objects.
  */
-export abstract class AbstractJSONTable<DST, TableName extends keyof DST & string, Content extends IJSONContent> extends AbstractTable<DST, TableName> {
+export abstract class AbstractJSONRepository<DST, TableName extends keyof DST & string, Content extends IJSONContent> extends AbstractRepository<DST, TableName> {
     private readonly supportedTypes: string[]
 
     constructor(
@@ -118,7 +118,7 @@ export abstract class AbstractJSONTable<DST, TableName extends keyof DST & strin
     }
 }
 
-export interface JSONContentBaseTable<T> extends AbstractTableSchema {
+export interface JSONContentBaseTable<T> extends AbstractRepositorySchema {
     type: string
     content: T
 }

--- a/src/datalayer/AbstractRepository.ts
+++ b/src/datalayer/AbstractRepository.ts
@@ -9,14 +9,14 @@ export interface TableConfig<TableName extends string> {
     hasPriority?: boolean
 }
 
-export interface AbstractTableSchema {
+export interface AbstractRepositorySchema {
     id: Generated<number>
     priority: PriorityColumn
     deleted_at: NullableTimestampDefault
     created_at: TimestampDefault
 }
 
-export abstract class AbstractTable<DST, TableName extends keyof DST & string> extends BaseTable<DST, TableName> {
+export abstract class AbstractRepository<DST, TableName extends keyof DST & string> extends BaseTable<DST, TableName> {
     protected readonly softDelete: boolean
     protected readonly hasPriority: boolean
 

--- a/src/datalayer/_tests_/AbstractCacheRepository.test.ts
+++ b/src/datalayer/_tests_/AbstractCacheRepository.test.ts
@@ -1,6 +1,6 @@
 import {Kysely, sql} from 'kysely';
 import RequestDataRepository, {createTestDb, DatabaseSchema} from "@datalayer/_tests_/testUtils";
-import {CacheEntry, TTL} from "@datalayer/AbstractCacheTable";
+import {CacheEntry, TTL} from "@datalayer/AbstractCacheRepository";
 
 describe('DatabaseRequestDataCache', () => {
     let db: Kysely<DatabaseSchema>

--- a/src/datalayer/_tests_/AbstractJSONRepository.test.ts
+++ b/src/datalayer/_tests_/AbstractJSONRepository.test.ts
@@ -6,7 +6,7 @@ import {
     DatabaseSchema
 } from "@datalayer/_tests_/testUtils";
 
-describe('AbstractJSONTable', () => {
+describe('AbstractJSONRepository', () => {
     let db: Kysely<DatabaseSchema>
     let repository: DashboardConfigurationRepository
 

--- a/src/datalayer/_tests_/AbstractRepository.test.ts
+++ b/src/datalayer/_tests_/AbstractRepository.test.ts
@@ -1,6 +1,6 @@
 import {Kysely} from 'kysely'
 import {ColumnSpec, ColumnType} from '../entities'
-import {AbstractTable} from '../AbstractTable'
+import {AbstractRepository} from '../AbstractRepository'
 import {createTestDb, DatabaseSchema, UsersRepository} from "@datalayer/_tests_/testUtils";
 
 describe('UsersRepository CRUD', () => {
@@ -62,8 +62,8 @@ describe('UsersRepository CRUD', () => {
     })
 })
 
-describe('AbstractTable feature toggles', () => {
-    class UsersRepositoryNoFeatures extends AbstractTable<DatabaseSchema, 'users'> {
+describe('AbstractRepository feature toggles', () => {
+    class UsersRepositoryNoFeatures extends AbstractRepository<DatabaseSchema, 'users'> {
         constructor(db: Kysely<DatabaseSchema>) {
             super(db, 'users')
         }

--- a/src/datalayer/_tests_/testUtils.ts
+++ b/src/datalayer/_tests_/testUtils.ts
@@ -1,10 +1,10 @@
 import type {NextApiRequest, NextApiResponse} from 'next'
-import {AbstractCacheTable, CacheBaseTable} from "@datalayer/AbstractCacheTable";
+import {AbstractCacheRepository, CacheBaseTable} from "@datalayer/AbstractCacheRepository";
 import {ColumnSpec, ColumnType} from "@datalayer/entities";
 import {Kysely, PostgresDialect, sql, SqliteDialect} from "kysely";
-import {AbstractTable, AbstractTableSchema} from "@datalayer/AbstractTable";
+import {AbstractRepository, AbstractRepositorySchema} from "@datalayer/AbstractRepository";
 import {IJSONContent} from "@datalayer/IJSONContent";
-import {AbstractJSONTable, JSONContentBaseTable} from "@datalayer/AbstractJSONTable";
+import {AbstractJSONRepository, JSONContentBaseTable} from "@datalayer/AbstractJSONRepository";
 import {AbstractKeyValueTable, KeyValueBaseTable} from "@datalayer/AbstractKeyValueTable";
 import BetterSqlite3 from "better-sqlite3";
 import {Pool} from "pg";
@@ -33,7 +33,7 @@ export function createMock(method: string, body: any = {}, query: any = {}) {
     return {req, res: res as NextApiResponse}
 }
 
-export default class RequestDataRepository extends AbstractCacheTable<DatabaseSchema, 'request_data_cache'> {
+export default class RequestDataRepository extends AbstractCacheRepository<DatabaseSchema, 'request_data_cache'> {
     constructor(db: Kysely<DatabaseSchema>) {
         super(db, 'request_data_cache')
     }
@@ -46,7 +46,7 @@ export default class RequestDataRepository extends AbstractCacheTable<DatabaseSc
     }
 }
 
-export class UsersRepository extends AbstractTable<DatabaseSchema, 'users'> {
+export class UsersRepository extends AbstractRepository<DatabaseSchema, 'users'> {
 
     constructor(database: Kysely<DatabaseSchema>) {
         super(database, {tableName: 'users', softDelete: true, hasPriority: true})
@@ -69,7 +69,7 @@ export interface DashboardConfiguration extends IJSONContent {
     type: 'DASHBOARD'
 }
 
-export class DashboardConfigurationRepository extends AbstractJSONTable<DatabaseSchema, 'dashboard_configuration', DashboardConfiguration> {
+export class DashboardConfigurationRepository extends AbstractJSONRepository<DatabaseSchema, 'dashboard_configuration', DashboardConfiguration> {
     constructor(database: Kysely<DatabaseSchema>) {
         super(database, {tableName: 'dashboard_configuration', softDelete: true, hasPriority: true}, ['DASHBOARD'])
     }
@@ -86,7 +86,7 @@ export interface RequestDataCacheTable extends CacheBaseTable {
     metadata: unknown | null
 }
 
-export interface UsersTable extends AbstractTableSchema {
+export interface UsersTable extends AbstractRepositorySchema {
     name: string
     surname: string
     telephone_number: string
@@ -141,7 +141,7 @@ export async function createTestDb(): Promise<Kysely<DatabaseSchema>> {
     })
 }
 
-class TestTable extends AbstractTable<DatabaseSchema, 'users'> {
+class TestTable extends AbstractRepository<DatabaseSchema, 'users'> {
     protected extraColumns(): ColumnSpec[] {
         return []
     }
@@ -151,7 +151,7 @@ class TestTable extends AbstractTable<DatabaseSchema, 'users'> {
     }
 }
 
-class TestCacheTable extends AbstractCacheTable<DatabaseSchema, 'request_data_cache'> {
+class TestCacheTable extends AbstractCacheRepository<DatabaseSchema, 'request_data_cache'> {
     public getDialect(): string {
         return this.dialect
     }

--- a/src/servicelayer/BaseTableDataHandler.ts
+++ b/src/servicelayer/BaseTableDataHandler.ts
@@ -1,11 +1,11 @@
 import {Insertable, Kysely, Selectable, Updateable} from 'kysely'
 import {BaseHandler, ErrorCode, ResponseError} from './BaseHandler'
-import {AbstractTable} from "@datalayer/AbstractTable";
+import {AbstractRepository} from "@datalayer/AbstractRepository";
 import {ensureValidId} from "@datalayer/utilities";
 
 /**
  * Generic REST handler that wires HTTP verbs to repository operations
- * implemented by {@link AbstractTable}. Subclasses only need to provide
+ * implemented by {@link AbstractRepository}. Subclasses only need to provide
  * a repository instance via {@link getTable}.
  */
 export abstract class BaseTableDataHandler<DST, TableName extends keyof DST & string> extends BaseHandler<Array<Selectable<DST[TableName]>>> {
@@ -15,7 +15,7 @@ export abstract class BaseTableDataHandler<DST, TableName extends keyof DST & st
      * The repository is typically created using the Kysely instance from
      * {@link BaseHandler.db} and should have its schema ensured prior to use.
      */
-    protected abstract getTable(): Promise<AbstractTable<DST, TableName>>
+    protected abstract getTable(): Promise<AbstractRepository<DST, TableName>>
 
     /**
      * Subclasses must return the Kysely instance used for database operations.

--- a/src/servicelayer/JSONTableDataHandler.ts
+++ b/src/servicelayer/JSONTableDataHandler.ts
@@ -1,11 +1,11 @@
 import {Kysely} from 'kysely'
 import {BaseHandler, ErrorCode, ResponseError} from './BaseHandler'
-import {AbstractJSONTable} from '@datalayer/AbstractJSONTable'
+import {AbstractJSONRepository} from '@datalayer/AbstractJSONRepository'
 import {IJSONContent} from '@datalayer/IJSONContent'
 import {ensureValidId} from '@datalayer/utilities'
 
 /**
- * REST handler for tables based on {@link AbstractJSONTable}. Works similarly
+ * REST handler for tables based on {@link AbstractJSONRepository}. Works similarly
  * to {@link BaseTableDataHandler} but operates on JSON content objects.
  */
 export abstract class JSONTableDataHandler<
@@ -16,7 +16,7 @@ export abstract class JSONTableDataHandler<
     /**
      * Subclasses must return a repository instance for the table they manage.
      */
-    protected abstract getTable(): Promise<AbstractJSONTable<DST, TableName, Content>>
+    protected abstract getTable(): Promise<AbstractJSONRepository<DST, TableName, Content>>
 
     /**
      * Subclasses must return the Kysely instance used for database operations.


### PR DESCRIPTION
## Summary
- rename AbstractTable to AbstractRepository
- rename AbstractJSONTable to AbstractJSONRepository
- rename AbstractCacheTable to AbstractCacheRepository
- update documentation, imports, and tests to new repository naming

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a779af868c832da5cd082b71d5bd52