### PR TITLE
Rename AbstractKeyValueTable to AbstractKeyValueRepository

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Reusable TypeScript repository layer built on [Kysely](https://github.com/kysely
 - [x] `BaseTable` abstract class for shared table utilities
 - [x] `AbstractJSONRepository` for storing typed JSON content
 - [x] `AbstractCacheRepository` for simple cache management with TTL
-- [x] `AbstractKeyValueTable` for simple key/value storage
+- [x] `AbstractKeyValueRepository` for simple key/value storage
 
 ## API Usage
 
@@ -59,7 +59,7 @@ const exists = await cache.isCached({key: 'session1'}, TTL.ONE_DAY) // => true
 const data = await cache.getLast<{userId: number}>({key: 'session1'}, TTL.ONE_DAY) // => { userId: 1 }
 ```
 
-#### AbstractKeyValueTable
+#### AbstractKeyValueRepository
 
 Persist simple key/value pairs with typed values.
 
@@ -68,13 +68,13 @@ Persist simple key/value pairs with typed values.
 | 'THEME' | 'dark' |
 
 ```ts
-class SettingsTable extends AbstractKeyValueTable<DatabaseSchema, 'settings', string> {
+class SettingsRepository extends AbstractKeyValueRepository<DatabaseSchema, 'settings', string> {
     constructor(db: Kysely<DatabaseSchema>) {
         super(db, {tableName: 'settings', valueType: ColumnType.STRING})
     }
 }
 
-const settings = new SettingsTable(db)
+const settings = new SettingsRepository(db)
 await settings.setValue('THEME', 'dark')
 const obj = await settings.getObject() // => { THEME: 'dark' }
 ```

--- a/src/datalayer/AbstractKeyValueRepository.ts
+++ b/src/datalayer/AbstractKeyValueRepository.ts
@@ -12,7 +12,7 @@ export interface KeyValueTableConfig<TableName extends string> {
     valueType: ColumnType
 }
 
-export abstract class AbstractKeyValueTable<
+export abstract class AbstractKeyValueRepository<
     DST,
     TableName extends keyof DST & string,
     Value

--- a/src/datalayer/_tests_/AbstractKeyValueRepository.test.ts
+++ b/src/datalayer/_tests_/AbstractKeyValueRepository.test.ts
@@ -1,7 +1,7 @@
 import {Kysely} from 'kysely'
 import {createTestDb, DatabaseSchema, SettingsRepository} from '@datalayer/_tests_/testUtils'
 
-describe('AbstractKeyValueTable', () => {
+describe('AbstractKeyValueRepository', () => {
     let db: Kysely<DatabaseSchema>
     let repo: SettingsRepository
 

--- a/src/datalayer/_tests_/testUtils.ts
+++ b/src/datalayer/_tests_/testUtils.ts
@@ -5,7 +5,7 @@ import {Kysely, PostgresDialect, sql, SqliteDialect} from "kysely";
 import {AbstractRepository, AbstractRepositorySchema} from "@datalayer/AbstractRepository";
 import {IJSONContent} from "@datalayer/IJSONContent";
 import {AbstractJSONRepository, JSONContentBaseTable} from "@datalayer/AbstractJSONRepository";
-import {AbstractKeyValueTable, KeyValueBaseTable} from "@datalayer/AbstractKeyValueTable";
+import {AbstractKeyValueRepository, KeyValueBaseTable} from "@datalayer/AbstractKeyValueRepository";
 import BetterSqlite3 from "better-sqlite3";
 import {Pool} from "pg";
 
@@ -75,7 +75,7 @@ export class DashboardConfigurationRepository extends AbstractJSONRepository<Dat
     }
 }
 
-export class SettingsRepository extends AbstractKeyValueTable<DatabaseSchema, 'settings', string> {
+export class SettingsRepository extends AbstractKeyValueRepository<DatabaseSchema, 'settings', string> {
     constructor(database: Kysely<DatabaseSchema>) {
         super(database, {tableName: 'settings', valueType: ColumnType.STRING})
     }


### PR DESCRIPTION
## Summary
- rename `AbstractKeyValueTable` to `AbstractKeyValueRepository`
- update tests to use `AbstractKeyValueRepository`
- adjust documentation to refer to `AbstractKeyValueRepository`

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a77fcea548832d8ed8061824104710