### PR TITLE
Add integration layer transporter and token store

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Reusable TypeScript repository layer built on [Kysely](https://github.com/kysely
 - [x] `AbstractCacheRepository` for simple cache management with TTL
 - [x] `AbstractKeyValueRepository` for simple key/value storage
 
+## Integration Layer
+
+- **AuthorisedTransporter** — wraps `fetch` to perform REST calls against a base URL, injects bearer tokens from an `ITokenStore`, and caches side-effect-free GET responses through an `IRequestCache`.
+- **DatabaseTokenStore** — stores tokens in an `AbstractKeyValueRepository` and refreshes them via an `ITokenProvider`.
+
 ## API Usage
 
 ### Repository layer

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
     ],
     moduleNameMapper: {
         '^@datalayer(.*)$': '<rootDir>/src/datalayer$1',
-        '^@servicelayer(.*)$': '<rootDir>/src/servicelayer$1'
+        '^@servicelayer(.*)$': '<rootDir>/src/servicelayer$1',
+        '^@integrationlayer(.*)$': '<rootDir>/src/integrationlayer$1'
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "better-sqlite3": "^12.2.0",
+        "cross-fetch": "^4.1.0",
         "kysely": "^0.28.5",
         "next": "^15.5.0",
         "pg": "^8.16.3"
@@ -3458,6 +3459,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5635,6 +5645,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -6854,6 +6884,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -7127,6 +7163,22 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.2.0",
+    "cross-fetch": "^4.1.0",
     "kysely": "^0.28.5",
     "next": "^15.5.0",
     "pg": "^8.16.3"

--- a/src/integrationlayer/AuthorisedTransporter.ts
+++ b/src/integrationlayer/AuthorisedTransporter.ts
@@ -1,0 +1,88 @@
+import fetch from 'cross-fetch';
+import ITokenStore from './ITokenStore';
+import IRequestCache from './IRequestCache';
+
+/** Options for {@link AuthorisedTransporter}. */
+interface TransporterOptions {
+    baseUrl: string;
+    tokenStore?: ITokenStore;
+    requestCache?: IRequestCache;
+}
+
+/**
+ * Wrapper around `fetch` that injects a bearer token and caches GET
+ * requests using the provided interfaces.
+ */
+export default class AuthorisedTransporter {
+    private readonly baseUrl: string;
+    private readonly tokenStore?: ITokenStore;
+    private readonly requestCache?: IRequestCache;
+
+    constructor({baseUrl, tokenStore, requestCache}: TransporterOptions) {
+        if (!/^https?:\/\//.test(baseUrl)) {
+            throw new Error('baseUrl must start with http:// or https://');
+        }
+        this.baseUrl = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+        this.tokenStore = tokenStore;
+        this.requestCache = requestCache;
+    }
+
+    /**
+     * Execute an HTTP request and cache GET responses when a cache is provided.
+     */
+    private async request<T>(method: string, urlPart: string, body?: unknown): Promise<T> {
+        const url = new URL(urlPart, this.baseUrl).toString();
+        const headers: Record<string, string> = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        };
+        if (this.tokenStore) {
+            const token = await this.tokenStore.getToken();
+            if (token) headers['Authorization'] = `Bearer ${token}`;
+        }
+
+        if (method === 'GET' && this.requestCache) {
+            const cached = await this.requestCache.get<T>(url);
+            if (cached !== null) return cached;
+        }
+
+        const response = await fetch(url, {
+            method,
+            headers,
+            ...(body !== undefined ? {body: JSON.stringify(body)} : {})
+        });
+        if (!response.ok) {
+            const text = await response.text();
+            throw new Error(`Request failed: ${response.status} ${response.statusText}\n${text}`);
+        }
+        if (method === 'GET' && this.requestCache) {
+            const json = await response.json();
+            await this.requestCache.set(url, json);
+            return json;
+        }
+        if (response.status === 204) {
+            return undefined as unknown as T;
+        }
+        return response.json() as Promise<T>;
+    }
+
+    public get<T>(urlPart: string): Promise<T> {
+        return this.request('GET', urlPart);
+    }
+
+    public post<T>(urlPart: string, body?: unknown): Promise<T> {
+        return this.request('POST', urlPart, body);
+    }
+
+    public patch<T>(urlPart: string, body?: unknown): Promise<T> {
+        return this.request('PATCH', urlPart, body);
+    }
+
+    public delete<T>(urlPart: string): Promise<T> {
+        return this.request('DELETE', urlPart);
+    }
+
+    public put<T>(urlPart: string, body?: unknown): Promise<T> {
+        return this.request('PUT', urlPart, body);
+    }
+}

--- a/src/integrationlayer/DatabaseTokenStore.ts
+++ b/src/integrationlayer/DatabaseTokenStore.ts
@@ -1,0 +1,58 @@
+import {AbstractKeyValueRepository} from '@datalayer/AbstractKeyValueRepository';
+import ITokenStore from './ITokenStore';
+import ITokenProvider, {TokenData} from './ITokenProvider';
+
+/**
+ * Persists access tokens in a key–value repository and refreshes them
+ * using the supplied {@link ITokenProvider}.
+ */
+export default class DatabaseTokenStore implements ITokenStore {
+    private readonly repository: AbstractKeyValueRepository<any, any, TokenData>;
+    private readonly key: string;
+    private readonly provider: ITokenProvider;
+
+    constructor(
+        repository: AbstractKeyValueRepository<any, any, TokenData>,
+        key: string,
+        provider: ITokenProvider,
+    ) {
+        this.repository = repository;
+        this.key = key;
+        this.provider = provider;
+    }
+
+    /** Retrieve a valid token from storage, refreshing when necessary. */
+    async getToken(): Promise<string> {
+        const existing = await this.repository.getValue(this.key);
+        if (existing && (!existing.expiryDate || existing.expiryDate > Date.now())) {
+            return existing.token;
+        }
+        return this.refreshTokenInternal(existing ?? undefined);
+    }
+
+    /** Force a refresh of the token regardless of its expiry. */
+    async refreshToken(): Promise<string> {
+        const existing = await this.repository.getValue(this.key);
+        return this.refreshTokenInternal(existing ?? undefined);
+    }
+
+    /** Persist a freshly fetched token and return its value. */
+    private async refreshTokenInternal(existing?: TokenData): Promise<string> {
+        let data: TokenData;
+        if (
+            existing &&
+            existing.refreshToken &&
+            (!existing.refreshTokenExpiryDate || existing.refreshTokenExpiryDate > Date.now()) &&
+            this.provider.refreshExistingToken
+        ) {
+            data = await this.provider.refreshExistingToken(existing.refreshToken);
+        } else {
+            data = await this.provider.fetchNewToken();
+        }
+        if (!data.token) {
+            throw new Error('Token provider returned empty token');
+        }
+        await this.repository.setValue(this.key, data);
+        return data.token;
+    }
+}

--- a/src/integrationlayer/IRequestCache.ts
+++ b/src/integrationlayer/IRequestCache.ts
@@ -1,0 +1,11 @@
+export default interface IRequestCache {
+    /**
+     * Retrieve cached value for the key. Returns null when not found.
+     */
+    get<T>(key: string): Promise<T | null>;
+
+    /**
+     * Store value under the key.
+     */
+    set<T>(key: string, value: T): Promise<void>;
+}

--- a/src/integrationlayer/ITokenProvider.ts
+++ b/src/integrationlayer/ITokenProvider.ts
@@ -1,0 +1,15 @@
+/** Data returned from token provider. */
+export interface TokenData {
+    token: string;
+    /** When omitted the token is treated as non-expiring. */
+    expiryDate?: number;
+    refreshToken?: string;
+    refreshTokenExpiryDate?: number;
+}
+
+export default interface ITokenProvider {
+    /** Obtain a completely new access token. */
+    fetchNewToken(): Promise<TokenData>;
+    /** Refresh the token using the provided refresh token. */
+    refreshExistingToken?(refreshToken: string): Promise<TokenData>;
+}

--- a/src/integrationlayer/ITokenStore.ts
+++ b/src/integrationlayer/ITokenStore.ts
@@ -1,0 +1,11 @@
+export default interface ITokenStore {
+    /**
+     * Retrieve a valid access token.
+     */
+    getToken(): Promise<string>;
+
+    /**
+     * Force refresh the access token.
+     */
+    refreshToken(): Promise<string>;
+}

--- a/src/integrationlayer/_tests_/AuthorisedTransporter.test.ts
+++ b/src/integrationlayer/_tests_/AuthorisedTransporter.test.ts
@@ -1,0 +1,48 @@
+jest.mock('cross-fetch', () => jest.fn());
+
+import fetch from 'cross-fetch';
+import AuthorisedTransporter from '@integrationlayer/AuthorisedTransporter';
+import IRequestCache from '@integrationlayer/IRequestCache';
+import ITokenStore from '@integrationlayer/ITokenStore';
+
+const mockedFetch = fetch as unknown as jest.Mock;
+
+class MemoryCache implements IRequestCache {
+    private store = new Map<string, any>();
+    async get<T>(key: string): Promise<T | null> {
+        return this.store.get(key) ?? null;
+    }
+    async set<T>(key: string, value: T): Promise<void> {
+        this.store.set(key, value);
+    }
+}
+
+class StaticTokenStore implements ITokenStore {
+    constructor(private token: string) {}
+    async getToken(): Promise<string> {
+        return this.token;
+    }
+    async refreshToken(): Promise<string> {
+        return this.token;
+    }
+}
+
+describe('AuthorisedTransporter', () => {
+    test('uses Authorization header and caches GET', async () => {
+        mockedFetch.mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({value: 1}),
+        });
+        const cache = new MemoryCache();
+        const tokenStore = new StaticTokenStore('abc');
+        const transporter = new AuthorisedTransporter({baseUrl: 'https://example.com/', tokenStore, requestCache: cache});
+        const first = await transporter.get('data');
+        const second = await transporter.get('data');
+        expect(first).toEqual({value: 1});
+        expect(second).toEqual({value: 1});
+        expect(mockedFetch).toHaveBeenCalledTimes(1);
+        const headers = mockedFetch.mock.calls[0][1].headers;
+        expect(headers.Authorization).toBe('Bearer abc');
+    });
+});

--- a/src/integrationlayer/_tests_/DatabaseTokenStore.test.ts
+++ b/src/integrationlayer/_tests_/DatabaseTokenStore.test.ts
@@ -1,0 +1,48 @@
+import DatabaseTokenStore from '@integrationlayer/DatabaseTokenStore';
+import ITokenProvider, {TokenData} from '@integrationlayer/ITokenProvider';
+
+class MemoryRepository {
+    private store = new Map<string, any>();
+    async getValue(key: string): Promise<TokenData | null> {
+        return this.store.get(key) ?? null;
+    }
+    async setValue(key: string, value: TokenData): Promise<void> {
+        this.store.set(key, value);
+    }
+}
+
+describe('DatabaseTokenStore', () => {
+    test('retrieves and refreshes tokens', async () => {
+        const repo = new MemoryRepository();
+        const provider: ITokenProvider = {
+            fetchNewToken: jest.fn().mockResolvedValue({
+                token: 'token1',
+                expiryDate: Date.now() + 1000,
+                refreshToken: 'refresh1',
+                refreshTokenExpiryDate: Date.now() + 2000,
+            }),
+            refreshExistingToken: jest.fn().mockResolvedValue({
+                token: 'token2',
+                expiryDate: Date.now() + 1000,
+                refreshToken: 'refresh1',
+                refreshTokenExpiryDate: Date.now() + 2000,
+            }),
+        };
+
+        const store = new DatabaseTokenStore(repo as any, 'key', provider);
+        const token1 = await store.getToken();
+        expect(token1).toBe('token1');
+        expect((provider.fetchNewToken as jest.Mock)).toHaveBeenCalledTimes(1);
+
+        // expire token and ensure refresh is called
+        await repo.setValue('key', {
+            token: 'token1',
+            expiryDate: Date.now() - 1000,
+            refreshToken: 'refresh1',
+            refreshTokenExpiryDate: Date.now() + 2000,
+        });
+        const token2 = await store.getToken();
+        expect(token2).toBe('token2');
+        expect((provider.refreshExistingToken as jest.Mock)).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "DOM"],
     "rootDir": "src",
     "outDir": "dist",
     "strict": true,
@@ -13,7 +13,9 @@
       "@datalayer": ["datalayer"],
       "@datalayer/*": ["datalayer/*"],
       "@servicelayer": ["servicelayer"],
-      "@servicelayer/*": ["servicelayer/*"]
+      "@servicelayer/*": ["servicelayer/*"],
+      "@integrationlayer": ["integrationlayer"],
+      "@integrationlayer/*": ["integrationlayer/*"]
     }
   },
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
## Summary
- document new AuthorisedTransporter and DatabaseTokenStore classes and describe integration layer in README
- allow token providers to omit expiry dates and handle optional refresh expiries
- drop unused re-export index and include DOM lib for cross-fetch compatibility

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa18e145a8832dbeaaf8ecf927b4fd