### PR TITLE
feat: store JSON values in key-value repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ class SettingsRepository extends AbstractKeyValueRepository<DatabaseSchema, 'set
     }
 }
 
-const settings = new SettingsRepository(db)
-await settings.setValue('THEME', 'dark')
-const obj = await settings.getObject() // => { THEME: 'dark' }
+    const settings = new SettingsRepository(db)
+    await settings.setValue('THEME', 'dark')
+    const obj = await settings.exportData() // => { THEME: 'dark' }
 ```
 
 ### REST handler layer

--- a/src/datalayer/AbstractKeyValueRepository.ts
+++ b/src/datalayer/AbstractKeyValueRepository.ts
@@ -1,50 +1,69 @@
 import {Insertable, Kysely, Updateable, sql} from 'kysely'
-import {ColumnType} from './entities'
+import {ColumnType, TimestampDefault} from './entities'
 import {BaseTable} from './BaseTable'
+import {createdAtDefaultSql} from './utilities'
 
-export interface KeyValueBaseTable<V> {
+// ---- JSON typings ----
+export type JsonPrimitive = string | number | boolean | null
+export type JsonValue = JsonPrimitive | JsonValue[] | {[k: string]: JsonValue}
+
+function isPlainObject(x: unknown): x is Record<string, unknown> {
+    return (
+        typeof x === 'object' &&
+        x !== null &&
+        !Array.isArray(x) &&
+        Object.getPrototypeOf(x) === Object.prototype
+    )
+}
+
+function isJsonSerializable(x: unknown): x is JsonValue {
+    if (x === null || typeof x === 'string' || typeof x === 'boolean') return true
+    if (typeof x === 'number') return Number.isFinite(x)
+    if (Array.isArray(x)) return x.every(isJsonSerializable)
+    if (isPlainObject(x)) {
+        for (const v of Object.values(x)) if (!isJsonSerializable(v)) return false
+        return true
+    }
+    return false
+}
+
+function assertJsonSerializable(x: unknown): asserts x is JsonValue {
+    if (!isJsonSerializable(x)) {
+        throw new TypeError(
+            'Value is not JSON-serializable for jsonb. Allowed: null, string, finite number, boolean, arrays, plain objects.'
+        )
+    }
+}
+
+export interface KeyValueBaseTable {
     key: string
-    value: V | null
+    value: JsonValue | null
+    updated_at: TimestampDefault
 }
 
 export interface KeyValueTableConfig<TableName extends string> {
     tableName: TableName
-    valueType: ColumnType
 }
 
 export abstract class AbstractKeyValueRepository<
     DST,
     TableName extends keyof DST & string,
-    Value
 > extends BaseTable<DST, TableName> {
-    private readonly valueType: ColumnType
-
     constructor(database: Kysely<DST>, config: KeyValueTableConfig<TableName>) {
         super(database, config.tableName)
-        this.valueType = config.valueType
     }
 
-    protected encode(value: Value | null): unknown {
-        if (this.valueType === ColumnType.JSON) {
-            if (value == null) return null
-            return this.dialect === 'postgres' ? value : JSON.stringify(value)
-        }
-        return value as unknown
+    private encode(value: JsonValue | null): JsonValue | string | null {
+        if (value === null) return null
+        return this.dialect === 'sqlite' ? JSON.stringify(value) : value
     }
 
-    protected decode(value: unknown): Value | null {
-        if (this.valueType === ColumnType.JSON) {
-            if (value == null) return null as any
-            if (this.dialect === 'postgres') return value as Value
-            if (typeof value === 'string') {
-                try {
-                    return JSON.parse(value) as Value
-                } catch {
-                    return value as Value
-                }
-            }
+    private decode(value: unknown): JsonValue | null {
+        if (value == null) return null
+        if (this.dialect === 'sqlite' && typeof value === 'string') {
+            return JSON.parse(value)
         }
-        return value as Value | null
+        return value as JsonValue
     }
 
     async ensureSchema(): Promise<void> {
@@ -52,7 +71,12 @@ export abstract class AbstractKeyValueRepository<
         builder = builder.addColumn('key', 'varchar', col => col.notNull())
         builder = builder.addColumn(
             'value',
-            this.sqlApi.toStringType(this.valueType) as any,
+            this.sqlApi.toStringType(ColumnType.JSON) as any,
+        )
+        builder = builder.addColumn(
+            'updated_at',
+            'timestamp',
+            col => col.notNull().defaultTo(sql.raw(createdAtDefaultSql())),
         )
 
         builder = this.applyExtraColumns(builder)
@@ -64,55 +88,85 @@ export abstract class AbstractKeyValueRepository<
         )} (key)`.execute(this.db)
     }
 
-    async getValue(key: string): Promise<Value | null | undefined> {
+    async getAllKeys(): Promise<string[]> {
+        const rows = await this.db
+            .selectFrom(this.tableName as string)
+            .select(['key'])
+            .execute()
+        return (rows as any[]).map(r => r.key as string)
+    }
+
+    async getValue<T extends JsonValue = JsonValue>(
+        key: string,
+    ): Promise<T | null | undefined> {
         const row = await this.db
             .selectFrom(this.tableName as string)
             .select(['value'])
             .where('key', '=', key)
             .executeTakeFirst()
         if (!row) return undefined
-        return this.decode((row as any).value)
+        return this.decode((row as any).value) as T | null
     }
 
-    async setValue(key: string, value: Value | null): Promise<void> {
-        const encoded = this.encode(value)
+    async setValue(key: string, value: unknown): Promise<void> {
+        assertJsonSerializable(value)
+        const encoded = this.encode(value as JsonValue)
         const res = await (this.db.updateTable(this.tableName as string) as any)
-            .set({value: encoded} as Updateable<DST[TableName]>)
+            .set(
+                {value: encoded, updated_at: sql`CURRENT_TIMESTAMP`} as unknown as Updateable<
+                    DST[TableName]
+                >,
+            )
             .where('key', '=', key)
             .executeTakeFirst()
         const updated = (res as any)?.numUpdatedRows ?? 0n
         if (Number(updated) === 0) {
             await (this.db.insertInto(this.tableName as string) as any)
-                .values({key, value: encoded} as Insertable<DST[TableName]>)
+                .values(
+                    {key, value: encoded, updated_at: sql`CURRENT_TIMESTAMP`} as unknown as Insertable<
+                        DST[TableName]
+                    >,
+                )
                 .execute()
         }
     }
 
-    async getObject(): Promise<Record<string, Value | null>> {
+    async exportData(): Promise<Record<string, JsonValue | null>> {
         const rows = await this.db
             .selectFrom(this.tableName as string)
             .select(['key', 'value'])
             .execute()
-        const result: Record<string, Value | null> = {}
+        const result: Record<string, JsonValue | null> = {}
         for (const row of rows as any[]) {
             result[row.key] = this.decode(row.value)
         }
         return result
     }
 
-    async setObject(obj: Record<string, Value | null | undefined>): Promise<void> {
+    async importData(obj: Record<string, unknown | null | undefined>): Promise<void> {
         await this.db.transaction().execute(async trx => {
             for (const [key, value] of Object.entries(obj)) {
                 if (value === undefined) continue
-                const encoded = this.encode(value as Value | null)
+                assertJsonSerializable(value)
+                const encoded = this.encode(value as JsonValue)
                 const res = await (trx.updateTable(this.tableName as string) as any)
-                    .set({value: encoded} as Updateable<DST[TableName]>)
+                    .set(
+                        {value: encoded, updated_at: sql`CURRENT_TIMESTAMP`} as unknown as Updateable<
+                            DST[TableName]
+                        >,
+                    )
                     .where('key', '=', key)
                     .executeTakeFirst()
                 const updated = (res as any)?.numUpdatedRows ?? 0n
                 if (Number(updated) === 0) {
                     await (trx.insertInto(this.tableName as string) as any)
-                        .values({key, value: encoded} as Insertable<DST[TableName]>)
+                        .values(
+                            {
+                                key,
+                                value: encoded,
+                                updated_at: sql`CURRENT_TIMESTAMP`,
+                            } as unknown as Insertable<DST[TableName]>,
+                        )
                         .execute()
                 }
             }

--- a/src/datalayer/_tests_/AbstractKeyValueRepository.test.ts
+++ b/src/datalayer/_tests_/AbstractKeyValueRepository.test.ts
@@ -17,18 +17,34 @@ describe('AbstractKeyValueRepository', () => {
 
     test('setValue and getValue', async () => {
         await repo.setValue('THEME', 'dark')
-        const val = await repo.getValue('THEME')
-        expect(val).toBe('dark')
+        await repo.setValue('COUNT', 5)
+        await repo.setValue('CONFIG', {mode: 'light'})
+        const deep = {a: {b: {c: {d: [1, {e: 'f'}]}}}}
+        await repo.setValue('DEEP', deep)
+        expect(await repo.getValue('THEME')).toBe('dark')
+        expect(await repo.getValue('COUNT')).toBe(5)
+        expect(await repo.getValue('CONFIG')).toEqual({mode: 'light'})
+        expect(await repo.getValue('DEEP')).toEqual(deep)
     })
 
-    test('setObject updates multiple keys and handles null/undefined', async () => {
-        await repo.setObject({USER_TOKEN: 'abc', THEME: 'light'})
-        await repo.setObject({USER_TOKEN: null, THEME: undefined, LOCALE: 'en'})
+    test('importData updates multiple keys and handles null/undefined', async () => {
+        await repo.importData({USER_TOKEN: 'abc', THEME: 'light', COUNT: 1, CONFIG: {a: 1}})
+        await repo.importData({USER_TOKEN: null, THEME: undefined, LOCALE: 'en', CONFIG: {a: 2}})
         expect(await repo.getValue('USER_TOKEN')).toBeNull()
         expect(await repo.getValue('THEME')).toBe('light')
+        expect(await repo.getValue('COUNT')).toBe(1)
         expect(await repo.getValue('LOCALE')).toBe('en')
-        const all = await repo.getObject()
-        expect(all).toEqual({USER_TOKEN: null, THEME: 'light', LOCALE: 'en'})
+        expect(await repo.getValue('CONFIG')).toEqual({a: 2})
+        const keys = await repo.getAllKeys()
+        expect(new Set(keys)).toEqual(new Set(['USER_TOKEN', 'THEME', 'COUNT', 'LOCALE', 'CONFIG']))
+        const all = await repo.exportData()
+        expect(all).toEqual({USER_TOKEN: null, THEME: 'light', COUNT: 1, LOCALE: 'en', CONFIG: {a: 2}})
+    })
+
+    test('rejects non-serializable value and keeps old data', async () => {
+        await repo.setValue('SAFE', 'initial')
+        await expect(repo.setValue('SAFE', Buffer.from('abc') as any)).rejects.toThrow(TypeError)
+        expect(await repo.getValue('SAFE')).toBe('initial')
     })
 })
 

--- a/src/datalayer/_tests_/testUtils.ts
+++ b/src/datalayer/_tests_/testUtils.ts
@@ -75,9 +75,9 @@ export class DashboardConfigurationRepository extends AbstractJSONRepository<Dat
     }
 }
 
-export class SettingsRepository extends AbstractKeyValueRepository<DatabaseSchema, 'settings', string> {
+export class SettingsRepository extends AbstractKeyValueRepository<DatabaseSchema, 'settings'> {
     constructor(database: Kysely<DatabaseSchema>) {
-        super(database, {tableName: 'settings', valueType: ColumnType.STRING})
+        super(database, {tableName: 'settings'})
     }
 }
 
@@ -96,7 +96,7 @@ export interface DatabaseSchema {
     users: UsersTable
     request_data_cache: RequestDataCacheTable
     dashboard_configuration: JSONContentBaseTable<DashboardConfiguration>
-    settings: KeyValueBaseTable<string>
+    settings: KeyValueBaseTable
 }
 
 /**

--- a/src/integrationlayer/DatabaseTokenStore.ts
+++ b/src/integrationlayer/DatabaseTokenStore.ts
@@ -7,12 +7,12 @@ import ITokenProvider, {TokenData} from './ITokenProvider';
  * using the supplied {@link ITokenProvider}.
  */
 export default class DatabaseTokenStore implements ITokenStore {
-    private readonly repository: AbstractKeyValueRepository<any, any, TokenData>;
+    private readonly repository: AbstractKeyValueRepository<any, any>;
     private readonly key: string;
     private readonly provider: ITokenProvider;
 
     constructor(
-        repository: AbstractKeyValueRepository<any, any, TokenData>,
+        repository: AbstractKeyValueRepository<any, any>,
         key: string,
         provider: ITokenProvider,
     ) {
@@ -23,7 +23,7 @@ export default class DatabaseTokenStore implements ITokenStore {
 
     /** Retrieve a valid token from storage, refreshing when necessary. */
     async getToken(): Promise<string> {
-        const existing = await this.repository.getValue(this.key);
+        const existing = (await this.repository.getValue(this.key)) as TokenData | null | undefined;
         if (existing && (!existing.expiryDate || existing.expiryDate > Date.now())) {
             return existing.token;
         }
@@ -32,7 +32,7 @@ export default class DatabaseTokenStore implements ITokenStore {
 
     /** Force a refresh of the token regardless of its expiry. */
     async refreshToken(): Promise<string> {
-        const existing = await this.repository.getValue(this.key);
+        const existing = (await this.repository.getValue(this.key)) as TokenData | null | undefined;
         return this.refreshTokenInternal(existing ?? undefined);
     }
 

--- a/src/integrationlayer/_tests_/DatabaseTokenStore.test.ts
+++ b/src/integrationlayer/_tests_/DatabaseTokenStore.test.ts
@@ -7,7 +7,7 @@ class MemoryRepository {
         return this.store.get(key) ?? null;
     }
     async setValue(key: string, value: TokenData): Promise<void> {
-        this.store.set(key, value);
+        this.store.set(key, value)
     }
 }
 


### PR DESCRIPTION
## Summary
- track update timestamps for key-value entries and refresh them on each write
- add tests for deeply nested objects and non-serializable values to ensure input validation

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa3608edf4832daedb2c26d4ab3200