### PR TITLE
feature: add cache-aware transporter subclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Reusable TypeScript repository layer built on [Kysely](https://github.com/kysely
 
 ## Integration Layer
 
-- **AuthorisedTransporter** — wraps `fetch` to perform REST calls against a base URL, injects bearer tokens from an `ITokenStore`, and caches side-effect-free GET responses through an `IRequestCache`.
+- **AuthorisedTransporter** — wraps `fetch` to perform REST calls against a base URL and injects bearer tokens from an `ITokenStore`.
+- **AuthorisedCachedTransporter** — extends `AuthorisedTransporter` and adds `getWithCache` for caching side-effect-free GET responses through an `IRequestCache`.
 - **DatabaseTokenStore** — stores tokens in an `AbstractKeyValueRepository` and refreshes them via an `ITokenProvider`.
 
 ## API Usage

--- a/src/integrationlayer/AuthorisedCachedTransporter.ts
+++ b/src/integrationlayer/AuthorisedCachedTransporter.ts
@@ -1,0 +1,39 @@
+import {CacheEntry, TTL} from '@datalayer/AbstractCacheRepository';
+import IRequestCache from './IRequestCache';
+import AuthorisedTransporter, {TransporterOptions} from './AuthorisedTransporter';
+
+/**
+ * Transporter that adds caching capabilities to {@link AuthorisedTransporter}.
+ *
+ * A cache implementation must be provided and GET responses are cached using a
+ * composite {@link CacheEntry} key.
+ */
+export default class AuthorisedCachedTransporter extends AuthorisedTransporter {
+    protected readonly requestCache: IRequestCache;
+
+    constructor(options: TransporterOptions & {requestCache: IRequestCache}) {
+        super(options);
+        if (!options.requestCache) {
+            throw new Error('requestCache is required for AuthorisedCachedTransporter');
+        }
+        this.requestCache = options.requestCache;
+    }
+
+    /**
+     * Execute a GET request and cache the response using the configured cache.
+     */
+    public async getWithCache<T>(
+        urlPart: string,
+        type: string,
+        ttl: TTL = TTL.UNLIMITED,
+        cacheKeyParts?: Partial<CacheEntry<any>>,
+    ): Promise<T> {
+        const cacheKey = {key: urlPart, type, ...cacheKeyParts};
+        const cached = await this.requestCache.getLast<T>(cacheKey, ttl);
+        if (cached !== null) return cached;
+        const result = await this.get<T>(urlPart);
+        await this.requestCache.save(cacheKey, result);
+        return result;
+    }
+}
+

--- a/src/integrationlayer/IRequestCache.ts
+++ b/src/integrationlayer/IRequestCache.ts
@@ -1,11 +1,13 @@
+import {CacheEntry, TTL} from '@datalayer/AbstractCacheRepository';
+
 export default interface IRequestCache {
     /**
-     * Retrieve cached value for the url. Returns null when not found.
+     * Retrieve last cached value matching select criteria. Returns null when not found or expired.
      */
-    get<T>(url: string): Promise<T | null>;
+    getLast<T>(select: Partial<CacheEntry<T>>, ttl?: TTL): Promise<T | null>;
 
     /**
-     * Store value under the key.
+     * Persist the value under the provided cache key.
      */
-    set<T>(url: string, value: T): Promise<void>;
+    save<T>(record: {key: string; type: string; [key: string]: any}, content: T): Promise<boolean>;
 }


### PR DESCRIPTION
## Summary
- export transporter options and expose request internals for subclassing
- add `AuthorisedCachedTransporter` implementing cache-aware `getWithCache`
- cover all HTTP verbs and cache persistence with integration tests

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab5bb29800832db1184ab1764567a5