### PR TITLE
Rename repository JSON methods and add type filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ class DashboardRepository extends AbstractJSONRepository<DatabaseSchema, 'dashbo
 
 const repo = new DashboardRepository(db)
 await repo.ensureSchema()
-const created = await repo.createWithContent({type: 'DASHBOARD', title: 'Main'}) // => { id: 1, priority: 0, type: 'DASHBOARD', title: 'Main' }
-const fetched = await repo.getByIdWithContent(created.id!) // => { id: 1, priority: 0, type: 'DASHBOARD', title: 'Main' }
+const created = await repo.jsonCreate({type: 'DASHBOARD', title: 'Main'}) // => { id: 1, priority: 0, type: 'DASHBOARD', title: 'Main' }
+const fetched = await repo.jsonGetById(created.id!) // => { id: 1, priority: 0, type: 'DASHBOARD', title: 'Main' }
 ```
 
 #### AbstractCacheRepository
@@ -130,7 +130,7 @@ export default (req: NextApiRequest, res: NextApiResponse) =>
 
 ##### Supported HTTP methods
 
-- **GET** `?id=<id>` → fetch a single row, omit `id` to list all rows. Response: array of rows.
+- **GET** `?id=<id>` → fetch a single row, omit `id` to fetch all rows. Response: array of rows.
 - **POST** body `{...}` → create a row. Response: array with the created row.
 - **PATCH** body `{id, ...fields}` → update a row. Body `{id, priority}` updates only priority.
 - **DELETE** body `{id}` → soft delete a row. Response: array with the deleted row.

--- a/src/datalayer/AbstractRepository.ts
+++ b/src/datalayer/AbstractRepository.ts
@@ -122,7 +122,7 @@ export abstract class AbstractRepository<DST, TableName extends keyof DST & stri
         return (await query.executeTakeFirst()) as Selectable<DST[TableName]> | undefined
     }
 
-    async list(options: {
+    async getAll(options: {
         includeDeleted?: boolean
         limit?: number
         offset?: number

--- a/src/datalayer/_tests_/AbstractRepository.test.ts
+++ b/src/datalayer/_tests_/AbstractRepository.test.ts
@@ -57,7 +57,7 @@ describe('UsersRepository CRUD', () => {
         const u2 = await repo.create({name: 'B', surname: 'B', telephone_number: '2', priority: 1})
         const u3 = await repo.create({name: 'C', surname: 'C', telephone_number: '3', priority: 2})
         await repo.updatePriority(u3.id, 1)
-        const list = await repo.list({orderBy: {column: 'priority'}})
+        const list = await repo.getAll({orderBy: {column: 'priority'}})
         expect(list.map((u) => u.id)).toEqual([u1.id, u3.id, u2.id])
     })
 })
@@ -97,5 +97,28 @@ describe('AbstractRepository feature toggles', () => {
 
         const c2 = await repo.create({name: 'A', surname: 'B', telephone_number: '2'})
         await expect(repo.updatePriority(c2.id, 1)).rejects.toThrow('Priority feature not enabled')
+    })
+})
+
+describe('AbstractRepository getAll', () => {
+    let db: Kysely<DatabaseSchema>
+    let repo: UsersRepository
+
+    beforeEach(async () => {
+        db = await createTestDb()
+        repo = new UsersRepository(db)
+        await repo.ensureSchema()
+    })
+
+    afterEach(async () => {
+        await db.destroy()
+    })
+
+    test('getAll returns all users', async () => {
+        await repo.create({name: 'A', surname: 'A', telephone_number: '1'})
+        await repo.create({name: 'B', surname: 'B', telephone_number: '2'})
+        const users = await repo.getAll({orderBy: {column: 'id'}})
+        expect(users).toHaveLength(2)
+        expect(users.map(u => u.name)).toEqual(['A', 'B'])
     })
 })

--- a/src/servicelayer/BaseTableDataHandler.ts
+++ b/src/servicelayer/BaseTableDataHandler.ts
@@ -42,7 +42,7 @@ export abstract class BaseTableDataHandler<DST, TableName extends keyof DST & st
             return
         }
 
-        const list = await table.list()
+        const list = await table.getAll()
         this.ok(await this.postGet(list))
     }
 

--- a/src/servicelayer/JSONTableDataHandler.ts
+++ b/src/servicelayer/JSONTableDataHandler.ts
@@ -33,7 +33,7 @@ export abstract class JSONTableDataHandler<
                 throw new ResponseError(ErrorCode.BAD_REQUEST, 'Invalid id')
             }
 
-            const row = await table.getByIdWithContent(id)
+            const row = await table.jsonGetById(id)
             if (row) {
                 this.ok(await this.postGet([row]))
             } else {
@@ -41,15 +41,20 @@ export abstract class JSONTableDataHandler<
             }
             return
         }
+        if (params['type'] !== undefined) {
+            const list = await table.jsonGetAllByType(params['type'])
+            this.ok(await this.postGet(list))
+            return
+        }
 
-        const list = await table.listWithContent()
+        const list = await table.jsonGetAll()
         this.ok(await this.postGet(list))
     }
 
     // ----- POST: create new content row
     protected async post(body: Content): Promise<void> {
         const table = await this.getTable()
-        const created = await table.createWithContent(body)
+        const created = await table.jsonCreate(body)
         await this.postProcess(await this.getDb())
         this.ok([created])
     }
@@ -65,10 +70,10 @@ export abstract class JSONTableDataHandler<
             Object.keys(body).length === 2
         ) {
             await table.updatePriority(body.id, (body as any).priority)
-            updated = await table.getByIdWithContent(body.id)
+            updated = await table.jsonGetById(body.id)
         } else {
             const {id, ...rest} = body as any
-            updated = await table.updateWithContent(id, rest)
+            updated = await table.jsonUpdate(id, rest)
         }
 
         if (updated) {
@@ -87,7 +92,7 @@ export abstract class JSONTableDataHandler<
         const deleted = await table.delete(body.id)
         if (deleted) {
             await this.postProcess(await this.getDb())
-            const content = await table.getByIdWithContent(body.id, {includeDeleted: true})
+            const content = await table.jsonGetById(body.id, {includeDeleted: true})
             if (content) {
                 this.ok([content])
             } else {

--- a/src/servicelayer/_tests_/JSONTableDataHandler.test.ts
+++ b/src/servicelayer/_tests_/JSONTableDataHandler.test.ts
@@ -42,7 +42,7 @@ describe('JSONTableDataHandler CRUD flow', () => {
 
         const repo = new DashboardConfigurationRepository(db)
         await repo.ensureSchema()
-        const inDb = await repo.getByIdWithContent(created.id!)
+        const inDb = await repo.jsonGetById(created.id!)
         expect(inDb?.title).toBe('Main')
     })
 
@@ -50,7 +50,7 @@ describe('JSONTableDataHandler CRUD flow', () => {
         expect.assertions(2)
         const repo = new DashboardConfigurationRepository(db)
         await repo.ensureSchema()
-        const created = await repo.createWithContent({
+        const created = await repo.jsonCreate({
             type: 'DASHBOARD',
             title: 'Dash',
             description: 'd',
@@ -68,7 +68,7 @@ describe('JSONTableDataHandler CRUD flow', () => {
         expect.assertions(3)
         const repo = new DashboardConfigurationRepository(db)
         await repo.ensureSchema()
-        const created = await repo.createWithContent({
+        const created = await repo.jsonCreate({
             type: 'DASHBOARD',
             title: 'Old',
             description: 'before',
@@ -79,7 +79,7 @@ describe('JSONTableDataHandler CRUD flow', () => {
         const {req, res} = createMock('PATCH', {id: created.id, description: 'after'})
         await new DashboardHandler(req, res).handle()
         expect(res.statusCode).toBe(200)
-        const updated = await repo.getByIdWithContent(created.id!)
+        const updated = await repo.jsonGetById(created.id!)
         expect(updated?.description).toBe('after')
         expect((res as any).data[0].description).toBe('after')
     })
@@ -88,7 +88,7 @@ describe('JSONTableDataHandler CRUD flow', () => {
         expect.assertions(3)
         const repo = new DashboardConfigurationRepository(db)
         await repo.ensureSchema()
-        const created = await repo.createWithContent({
+        const created = await repo.jsonCreate({
             type: 'DASHBOARD',
             title: 'ToDelete',
             description: 'd',
@@ -99,9 +99,33 @@ describe('JSONTableDataHandler CRUD flow', () => {
         const {req, res} = createMock('DELETE', {id: created.id})
         await new DashboardHandler(req, res).handle()
         expect(res.statusCode).toBe(200)
-        const deleted = await repo.getByIdWithContent(created.id!)
+        const deleted = await repo.jsonGetById(created.id!)
         expect(deleted).toBeUndefined()
         expect((res as any).data[0].id).toBe(created.id)
+    })
+
+    test('lists configurations by type', async () => {
+        expect.assertions(2)
+        const repo = new DashboardConfigurationRepository(db)
+        await repo.ensureSchema()
+        await repo.jsonCreate({
+            type: 'DASHBOARD',
+            title: 'One',
+            description: 'd1',
+            panelsIds: [],
+            variables: {},
+        })
+        await repo.jsonCreate({
+            type: 'DASHBOARD',
+            title: 'Two',
+            description: 'd2',
+            panelsIds: [],
+            variables: {},
+        })
+        const {req, res} = createMock('GET', undefined, {type: 'DASHBOARD'})
+        await new DashboardHandler(req, res).handle()
+        expect(res.statusCode).toBe(200)
+        expect((res as any).data).toHaveLength(2)
     })
 })
 


### PR DESCRIPTION
## Summary
- rename AbstractRepository.list to getAll
- rename AbstractJSONRepository methods to json* and add jsonGetAllByType
- update handlers, README, and tests for new method names

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0bea5bb30832da6e67e12b49be579