### PR TITLE
Add updateCache method and rename cache save to create

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ class RequestCacheRepository extends AbstractCacheRepository<DatabaseSchema, 're
 }
 
 const cache = new RequestCacheRepository(db)
-await cache.save({key: 'session1', type: 'SESSION'}, {userId: 1})
+await cache.create({key: 'session1', type: 'SESSION'}, {userId: 1})
 const exists = await cache.isCached({key: 'session1'}, TTL.ONE_DAY) // => true
 const data = await cache.getLast<{userId: number}>({key: 'session1'}, TTL.ONE_DAY) // => { userId: 1 }
 ```

--- a/src/integrationlayer/IRequestCache.ts
+++ b/src/integrationlayer/IRequestCache.ts
@@ -9,5 +9,10 @@ export default interface IRequestCache {
     /**
      * Persist the value under the provided cache key.
      */
-    save<T>(record: {key: string; type: string; [key: string]: any}, content: T): Promise<boolean>;
+    create<T>(record: {key: string; type: string; [key: string]: any}, content: T): Promise<boolean>;
+
+    /**
+     * Expire existing cached entries that match provided criteria.
+     */
+    expireEntries(select: Record<string, any>, ttl: TTL): Promise<number>;
 }

--- a/src/integrationlayer/_tests_/AuthorisedTransporter.test.ts
+++ b/src/integrationlayer/_tests_/AuthorisedTransporter.test.ts
@@ -5,6 +5,7 @@ import AuthorisedTransporter from '@integrationlayer/AuthorisedTransporter';
 import AuthorisedCachedTransporter from '@integrationlayer/AuthorisedCachedTransporter';
 import ITokenStore from '@integrationlayer/ITokenStore';
 import RequestDataRepository, {createTestDb} from '@datalayer/_tests_/testUtils';
+import {TTL} from '@datalayer/AbstractCacheRepository';
 
 const mockedFetch = fetch as unknown as jest.Mock;
 
@@ -109,6 +110,110 @@ describe('AuthorisedCachedTransporter', () => {
         await transporter.getWithCache('/data/', 'TEST');
         await transporter.getWithCache('data', 'TEST');
         expect(mockedFetch).toHaveBeenCalledTimes(1);
+        await db.destroy();
+    });
+
+    test('updateCache replaces cached entry on success', async () => {
+        mockedFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({value: 1}),
+        });
+        const db = await createTestDb();
+        const repo = new RequestDataRepository(db);
+        await repo.ensureSchema();
+        const transporter = new AuthorisedCachedTransporter('https://example.com/', repo);
+        await transporter.getWithCache('data', 'TEST');
+
+        mockedFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({value: 2}),
+        });
+        const updated = await transporter.updateCache('data', 'TEST');
+        expect(updated).toEqual({value: 2});
+
+        const fromCache = await transporter.getWithCache('data', 'TEST');
+        expect(fromCache).toEqual({value: 2});
+        expect(mockedFetch).toHaveBeenCalledTimes(2);
+
+        const all = await repo.getAll({key: 'data', type: 'TEST'}, TTL.UNLIMITED);
+        expect(all.length).toBe(2);
+        const fresh = await repo.getAll({key: 'data', type: 'TEST'}, TTL.NOT_EXPIRED);
+        expect(fresh.length).toBe(1);
+        await db.destroy();
+    });
+
+    test('updateCache propagates errors and keeps previous cache', async () => {
+        const db = await createTestDb();
+        const repo = new RequestDataRepository(db);
+        await repo.ensureSchema();
+        await repo.create({key: 'data', type: 'TEST'}, {value: 1});
+        const transporter = new AuthorisedCachedTransporter('https://example.com/', repo);
+
+        mockedFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+            statusText: 'ERR',
+            text: async () => 'ERR',
+        });
+        await expect(transporter.updateCache('data', 'TEST')).rejects.toThrow(/500/);
+
+        const cached = await transporter.getWithCache('data', 'TEST');
+        expect(cached).toEqual({value: 1});
+        expect(mockedFetch).toHaveBeenCalledTimes(1);
+        await db.destroy();
+    });
+
+    test('full cache workflow: getWithCache, updateCache, and cleanExpiredEntries', async () => {
+        mockedFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => ({orders: [{id: 1, total: 10}]}),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => ({users: [{id: 1, name: 'Alice'}, {id: 2, name: 'Bob'}]}),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => ({orders: [{id: 1, total: 10}, {id: 2, total: 20}]}),
+            });
+
+        const db = await createTestDb();
+        const repo = new RequestDataRepository(db);
+        await repo.ensureSchema();
+        const transporter = new AuthorisedCachedTransporter('https://example.com/', repo);
+
+        const firstOrders = await transporter.getWithCache('orders', 'WORKFLOW');
+        const secondOrders = await transporter.getWithCache('orders', 'WORKFLOW');
+        expect(firstOrders).toEqual({orders: [{id: 1, total: 10}]});
+        expect(secondOrders).toEqual({orders: [{id: 1, total: 10}]});
+        expect(mockedFetch).toHaveBeenCalledTimes(1);
+
+        const users = await transporter.updateCache('users', 'WORKFLOW');
+        expect(users).toEqual({users: [{id: 1, name: 'Alice'}, {id: 2, name: 'Bob'}]});
+        const refreshedOrders = await transporter.updateCache('orders', 'WORKFLOW');
+        expect(refreshedOrders).toEqual({orders: [{id: 1, total: 10}, {id: 2, total: 20}]});
+
+        const cachedOrders = await transporter.getWithCache('orders', 'WORKFLOW');
+        expect(cachedOrders).toEqual({orders: [{id: 1, total: 10}, {id: 2, total: 20}]});
+        expect(mockedFetch).toHaveBeenCalledTimes(3);
+
+        const allBefore = await repo.getAll({type: 'WORKFLOW'}, TTL.UNLIMITED);
+        expect(allBefore).toHaveLength(3);
+
+        const removed = await repo.cleanExpiredEntries({type: 'WORKFLOW'});
+        expect(removed).toBe(1);
+
+        const allAfter = await repo.getAll({type: 'WORKFLOW'}, TTL.UNLIMITED);
+        expect(allAfter).toHaveLength(2);
+        const keys = allAfter.map((e) => e.key).sort();
+        expect(keys).toEqual(['orders', 'users']);
+
         await db.destroy();
     });
 });


### PR DESCRIPTION
## Summary
- rename AbstractCacheRepository.save to create and allow expireEntries with unlimited TTL
- clarify AuthorisedCachedTransporter caching behavior and add updateCache to refresh entries
- cover updateCache happy and unhappy paths with tests
- add full workflow test verifying caching, update, and cleanup

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1a593efa8832d853ed733edf7fe9f